### PR TITLE
Sets random seed for np.random.

### DIFF
--- a/src/data_generators/synthetic_data_design_generator.py
+++ b/src/data_generators/synthetic_data_design_generator.py
@@ -114,6 +114,7 @@ class SyntheticDataDesignGenerator:
         self._output_dir = output_dir
         self._data_design_config = data_design_config
         self._random_generator = np.random.default_rng(random_seed)
+        np.random.seed(random_seed)
         self._verbose = verbose
 
     def __call__(self) -> DataDesign:

--- a/src/driver/experiment_driver.py
+++ b/src/driver/experiment_driver.py
@@ -108,6 +108,7 @@ class ExperimentDriver:
         self._output_file = output_file
         self._intermediate_dir = intermediate_dir
         self._rng = np.random.default_rng(seed=random_seed)
+        np.random.seed(random_seed)
 
     def execute(self) -> pd.DataFrame:
         """Performs all experiments defined in an experimental design."""

--- a/src/driver/tests/experiment_driver_test.py
+++ b/src/driver/tests/experiment_driver_test.py
@@ -82,10 +82,9 @@ class ExperimentDriverTest(absltest.TestCase):
                 data_design_dir, simple_data_design_example.__file__, 1, False
             )
             data_design_generator()
-            rng = np.random.default_rng(seed=1)
             experimental_design = sample_experimental_design.__file__
             experiment_driver = ExperimentDriver(
-                data_design_dir, experimental_design, output_file, intermediate_dir, rng
+                data_design_dir, experimental_design, output_file, intermediate_dir, 1
             )
             result = experiment_driver.execute()
             self.assertEqual(result.shape[0], 2700)
@@ -103,10 +102,9 @@ class ExperimentDriverTest(absltest.TestCase):
                 data_design_dir, simple_data_design_example.__file__, 1, False
             )
             data_design_generator()
-            rng = np.random.default_rng(seed=1)
             experimental_design = m3_first_round_experimental_design.__file__
             experiment_driver = ExperimentDriver(
-                data_design_dir, experimental_design, output_file, intermediate_dir, rng
+                data_design_dir, experimental_design, output_file, intermediate_dir, 1
             )
             result = experiment_driver.execute()
             self.assertEqual(result.shape[0], 5184)
@@ -124,10 +122,9 @@ class ExperimentDriverTest(absltest.TestCase):
                 data_design_dir, simple_data_design_example.__file__, 1, False
             )
             data_design_generator()
-            rng = np.random.default_rng(seed=1)
             experimental_design = analysis_example_experimental_design.__file__
             experiment_driver = ExperimentDriver(
-                data_design_dir, experimental_design, output_file, intermediate_dir, rng
+                data_design_dir, experimental_design, output_file, intermediate_dir, 1
             )
             result = experiment_driver.execute()
             self.assertEqual(result.shape[0], 2592)


### PR DESCRIPTION
This ensures repeatability across runs.  The PyDOE library (and perhaps others) use numpy.random, which requires the seed to be set with np.random.seed().
