### PR TITLE
Modifies Gamma-Poisson model to return valid reach points for high spends

### DIFF
--- a/src/models/gamma_poisson_model.py
+++ b/src/models/gamma_poisson_model.py
@@ -583,7 +583,7 @@ class GammaPoissonModel(ReachCurve):
         if len(impressions) != 1:
             raise ValueError("Impressions vector must have a length of 1.")
         hist = self._expected_histogram(
-            impressions[0],
+            min(impressions[0], self._max_impressions - 1),
             self._max_impressions,
             self.max_reach,
             self._alpha,

--- a/src/models/tests/gamma_poisson_model_test.py
+++ b/src/models/tests/gamma_poisson_model_test.py
@@ -206,6 +206,18 @@ class GammaPoissonModelTest(absltest.TestCase):
                 f"Got {h_actual[i]} Expected {h_expected[i]}",
             )
 
+    @patch.object(
+        GammaPoissonModel, "_fit_histogram_fixed_N", return_value=(25000, 5.0, 2.0)
+    )
+    def test_overspend(self, mock_gamma_poisson_model):
+        # Imax = 25000, N = 10000, alpha = 5, beta = 2
+        h_training = [8124, 5464, 3191, 1679, 815, 371, 159, 64, 23, 6, 0]
+        rp = ReachPoint([20000], h_training, [200.0])
+        gpm = GammaPoissonModel([rp], max_reach=10000)
+        gpm._fit()
+        self.assertAlmostEqual(gpm.by_impressions([30000]).reach(1), 10000.0, delta=0.1)
+        self.assertAlmostEqual(gpm.by_spend([300]).reach(1), 10000.0, delta=0.1)
+
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
Previously, if a spend value was given that exceeded the total cost of all impressions, the GammaPoisson model returned NaN's for all reach values.  This PR modifies the behavior of GammaPoisson model so that instead it returns the last point on the reach curve.
