### PR TITLE
Adds ground truth for reach curves as an evaluation option for M3

### DIFF
--- a/src/driver/m3_first_round_experimental_design.py
+++ b/src/driver/m3_first_round_experimental_design.py
@@ -44,6 +44,14 @@ from wfa_planning_evaluation_framework.driver.trial_descriptor import (
 
 MODELING_STRATEGIES = [
     ModelingStrategyDescriptor(
+        "m3strategy",
+        {"use_ground_truth_for_reach_curves": True},
+        "goerg",
+        {},
+        "restricted_pairwise_union",
+        {},
+    ),
+    ModelingStrategyDescriptor(
         "m3strategy", {}, "goerg", {}, "restricted_pairwise_union", {}
     ),
     ModelingStrategyDescriptor(

--- a/src/driver/tests/experiment_driver_test.py
+++ b/src/driver/tests/experiment_driver_test.py
@@ -59,7 +59,7 @@ class ExperimentDriverTest(absltest.TestCase):
                 np.random.default_rng(seed=1)
             )
         )
-        self.assertLen(list(sample_design), 192)
+        self.assertLen(list(sample_design), 288)
 
     def test_single_publisher_design(self):
         sp_design = list(
@@ -107,7 +107,7 @@ class ExperimentDriverTest(absltest.TestCase):
                 data_design_dir, experimental_design, output_file, intermediate_dir, 1
             )
             result = experiment_driver.execute()
-            self.assertEqual(result.shape[0], 5184)
+            self.assertEqual(result.shape[0], 7776)
 
     @patch(
         "wfa_planning_evaluation_framework.driver.experiment.ExperimentalTrial",

--- a/src/models/ground_truth_reach_curve_model.py
+++ b/src/models/ground_truth_reach_curve_model.py
@@ -1,0 +1,74 @@
+# Copyright 2021 The Private Cardinality Estimation Framework Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ground Truth Reach Curve Model.
+
+Reports the true reach as a function of spend or impressions.
+"""
+
+from wfa_planning_evaluation_framework.data_generators.data_set import DataSet
+from wfa_planning_evaluation_framework.models.reach_point import ReachPoint
+from wfa_planning_evaluation_framework.models.reach_curve import ReachCurve
+
+
+class GroundTruthReachCurveModel(ReachCurve):
+    """Ground Truth Reach Curve Model."""
+
+    def __init__(self, data_set: DataSet, publisher_index: int):
+        """Constructs an Goerg single point reach model.
+
+        Args:
+          data_set:  A DataSet object containing the underlying publisher
+            data for this simulation run.
+          publisher_index: The index of the publisher within the data_set
+            for which a ground truth reach curve is to be provided.
+        """
+        self._data_set = data_set
+        self._publisher_index = publisher_index
+        self._max_reach = data_set._data[publisher_index].max_reach
+
+    def by_impressions(self, impressions: [int], max_frequency: int = 1) -> ReachPoint:
+        """Returns the estimated reach as a function of impressions.
+
+        Args:
+          impressions: list of ints of length 1, specifying the hypothetical number
+            of impressions that are shown.
+          max_frequency: int, specifies the number of frequencies for which reach
+            will be reported.
+        Returns:
+          A ReachPoint specifying the estimated reach for this number of impressions.
+        """
+        if len(impressions) != 1:
+            raise ValueError("Impressions vector must have a length of 1.")
+        data_set_impressions = [0] * self._data_set.publisher_count
+        data_set_impressions[self._publisher_index] = impressions[0]
+        return self._data_set.reach_by_impressions(data_set_impressions, max_frequency)
+
+    def by_spend(self, spends: [int], max_frequency: int = 1) -> ReachPoint:
+        """Returns the estimated reach as a function of spend assuming constant CPM
+
+        Args:
+          spend: list of floats of length 1, specifying the hypothetical spend.
+          max_frequency: int, specifies the number of frequencies for which reach
+            will be reported.
+        Returns:
+          A ReachPoint specifying the estimated reach for this number of impressions.
+        """
+        if len(spends) != 1:
+            raise ValueError("Spend vector must have a length of 1.")
+        data_set_spends = [0] * self._data_set.publisher_count
+        data_set_spends[self._publisher_index] = spends[0]
+        return self._data_set.reach_by_spend(data_set_spends, max_frequency)
+
+    def impressions_for_spend(self, spend: float) -> int:
+        return self._data_set._data[self._publisher_index].impressions_by_spend(spend)

--- a/src/models/tests/ground_truth_reach_curve_model_test.py
+++ b/src/models/tests/ground_truth_reach_curve_model_test.py
@@ -1,0 +1,59 @@
+# Copyright 2021 The Private Cardinality Estimation Framework Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for GroundTruthReachCurveModel"""
+
+from absl.testing import absltest
+from numpy.random import RandomState
+from tempfile import TemporaryDirectory
+
+from wfa_planning_evaluation_framework.data_generators.publisher_data import (
+    PublisherData,
+)
+from wfa_planning_evaluation_framework.data_generators.data_set import DataSet
+from wfa_planning_evaluation_framework.models.ground_truth_reach_curve_model import (
+    GroundTruthReachCurveModel,
+)
+
+
+class GroundTruthReachCurveModelTest(absltest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pdf1 = PublisherData([(1, 0.01), (2, 0.02), (1, 0.04), (3, 0.05)], "pdf1")
+        pdf2 = PublisherData([(2, 0.03), (4, 0.06)], "pdf2")
+        data_set = DataSet([pdf1, pdf2], "test")
+        cls.data_set = data_set
+        cls.curve1 = GroundTruthReachCurveModel(data_set, 0)
+        cls.curve2 = GroundTruthReachCurveModel(data_set, 1)
+
+    def test_by_spend(self):
+        self.assertEqual(self.curve1.by_spend([0.0]).reach(1), 0)
+        self.assertEqual(self.curve2.by_spend([0.0]).reach(1), 0)
+        self.assertEqual(self.curve1.by_spend([0.02]).reach(1), 2)
+        self.assertEqual(self.curve2.by_spend([0.03]).reach(1), 1)
+
+    def test_by_impressions(self):
+        self.assertEqual(self.curve1.by_impressions([0]).reach(1), 0)
+        self.assertEqual(self.curve1.by_impressions([3]).reach(1), 2)
+        self.assertEqual(self.curve2.by_impressions([0]).reach(1), 0)
+        self.assertEqual(self.curve2.by_impressions([2]).reach(1), 2)
+
+    def test_impressions_for_spend(self):
+        self.assertEqual(self.curve1.impressions_for_spend(0.0), 0)
+        self.assertEqual(self.curve1.impressions_for_spend(0.05), 4)
+        self.assertEqual(self.curve2.impressions_for_spend(0.0), 0)
+        self.assertEqual(self.curve2.impressions_for_spend(0.05), 1)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
This PR adds the ability to compute the M3 model using the ground truth for the underlying reach curves.  This allows us to see how much modeling error is due to the single publisher models versus the restricted pairwise union reach curve model.