### PR TITLE
Modifies simulated_reach_by_spend so that it always generates consistent output

### DIFF
--- a/src/simulator/halo_simulator.py
+++ b/src/simulator/halo_simulator.py
@@ -202,6 +202,7 @@ class HaloSimulator:
         kplus_reaches = [
             round(x) for x in estimator.estimate_cardinality(combined_sketch)
         ]
+        kplus_reaches = np.minimum.accumulate(np.maximum(kplus_reaches, 0))
 
         # TODO(jiayu,pasin): Does this look right?
         for noiser_class, epsilon, delta in estimator.output_privacy_parameters():

--- a/src/simulator/tests/halo_simulator_test.py
+++ b/src/simulator/tests/halo_simulator_test.py
@@ -134,6 +134,18 @@ class HaloSimulatorTest(parameterized.TestCase):
         )
         self.assertTrue(reach_point.reach(1) >= 0)
 
+    @patch(
+        "wfa_planning_evaluation_framework.simulator.halo_simulator.StandardizedHistogramEstimator.estimate_cardinality"
+    )
+    def test_simulated_reach_by_spend_with_negative_noise(
+        self, mock_estimate_cardinality
+    ):
+        mock_estimate_cardinality.return_value = [10, 5, -1, 0, -1]
+        reach_point = self.halo.simulated_reach_by_spend(
+            [1.0, 1.0], PrivacyBudget(1.0, 0.0), 0.5, 5
+        )
+        self.assertTrue(all([reach_point.reach(i + 1) >= 0 for i in range(5)]))
+
     @parameterized.parameters(
         [1, 0],
         [1e5, 731820],


### PR DESCRIPTION
A basic property of k+ reach is that the k+ reach at frequency f is always nonnegative and at least as large as the k+ reach at frequency f+1.  Unfortunately, the StandardizedHistogramEstimator in the cardinality evaluation framework did not guarantee this property.  This PR modifies the output of StandardizedHistogramEstimator if necessary to ensure that the vector of k+ reach values is consistent.
