### PR TITLE
Exclude lambda functions from experimental configs

### DIFF
--- a/src/driver/analysis_example_experimental_design.py
+++ b/src/driver/analysis_example_experimental_design.py
@@ -19,10 +19,10 @@ import numpy as np
 from typing import Iterable
 
 from wfa_planning_evaluation_framework.driver.campaign_spend_fractions_generators import (
-    CAMPAIGN_SPEND_FRACTIONS_GENERATORS,
+    CampaignSpendFractionsGenerators,
 )
 from wfa_planning_evaluation_framework.driver.num_test_points_generators import (
-    NUM_TEST_POINTS_GENERATORS,
+    NumTestPointsGenerators,
 )
 from wfa_planning_evaluation_framework.driver.experiment_parameters import (
     ExperimentParameters,
@@ -54,8 +54,8 @@ MODELING_STRATEGIES = [
 ]
 
 CAMPAIGN_SPEND_FRACTIONS_GENERATORS = [
-    CAMPAIGN_SPEND_FRACTIONS_GENERATORS["all_0.6"],
-    CAMPAIGN_SPEND_FRACTIONS_GENERATORS["cyc_0.4_0.8"],
+    CampaignSpendFractionsGenerators.all_60,
+    CampaignSpendFractionsGenerators.cyc_40_80,
 ]
 
 LIQUID_LEGIONS_PARAMS = [
@@ -72,8 +72,8 @@ REPLICA_IDS = [1, 2, 3]
 MAX_FREQUENCIES = [3, 6]
 
 TEST_POINT_STRATEGIES = [
-    ("latin_hypercube", {"npoints_generator": NUM_TEST_POINTS_GENERATORS["10p"]}),
-    ("uniformly_random", {"npoints_generator": NUM_TEST_POINTS_GENERATORS["10p"]}),
+    ("latin_hypercube", {"npoints_generator": NumTestPointsGenerators.p_times_10}),
+    ("uniformly_random", {"npoints_generator": NumTestPointsGenerators.p_times_10}),
 ]
 
 LEVELS = {

--- a/src/driver/analysis_example_experimental_design.py
+++ b/src/driver/analysis_example_experimental_design.py
@@ -17,8 +17,13 @@ import itertools
 import math
 import numpy as np
 from typing import Iterable
-from itertools import cycle, islice
 
+from wfa_planning_evaluation_framework.driver.campaign_spend_fractions_generators import (
+    CAMPAIGN_SPEND_FRACTIONS_GENERATORS,
+)
+from wfa_planning_evaluation_framework.driver.num_test_points_generators import (
+    NUM_TEST_POINTS_GENERATORS,
+)
 from wfa_planning_evaluation_framework.driver.experiment_parameters import (
     ExperimentParameters,
 )
@@ -49,8 +54,8 @@ MODELING_STRATEGIES = [
 ]
 
 CAMPAIGN_SPEND_FRACTIONS_GENERATORS = [
-    lambda npublishers: [0.6] * npublishers,
-    lambda npublishers: list(islice(cycle([0.4, 0.8]), npublishers)),
+    CAMPAIGN_SPEND_FRACTIONS_GENERATORS["all_0.6"],
+    CAMPAIGN_SPEND_FRACTIONS_GENERATORS["cyc_0.4_0.8"],
 ]
 
 LIQUID_LEGIONS_PARAMS = [
@@ -67,8 +72,8 @@ REPLICA_IDS = [1, 2, 3]
 MAX_FREQUENCIES = [3, 6]
 
 TEST_POINT_STRATEGIES = [
-    ("latin_hypercube", {"npoints_generator": lambda npublishers: 10 * npublishers}),
-    ("uniformly_random", {"npoints_generator": lambda npublishers: 10 * npublishers}),
+    ("latin_hypercube", {"npoints_generator": NUM_TEST_POINTS_GENERATORS["10p"]}),
+    ("uniformly_random", {"npoints_generator": NUM_TEST_POINTS_GENERATORS["10p"]}),
 ]
 
 LEVELS = {

--- a/src/driver/campaign_spend_fractions_generators.py
+++ b/src/driver/campaign_spend_fractions_generators.py
@@ -1,0 +1,28 @@
+# Copyright 2021 The Private Cardinality Estimation Framework Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions to generate campaign_spend_fractions."""
+
+from itertools import cycle, islice
+
+# A dictionary of functions that maps the number of publishers p
+# to a list of length p.  The i-th element of the output list is
+# the campaign spend fraction at publisher i.
+
+CAMPAIGN_SPEND_FRACTIONS_GENERATORS = {
+    "all_0.2": lambda p: [0.2] * p,
+    "cyc_0.1_0.2_0.3": lambda p: list(islice(cycle([0.1, 0.2, 0.3]), p)),
+    "all_0.6": lambda p: [0.6] * p,
+    "cyc_0.4_0.8": lambda p: list(islice(cycle([0.4, 0.8]), p)),
+    "cyc_0.3_0.6_0.9": lambda p: list(islice(cycle([0.3, 0.6, 0.9]), p)),
+}

--- a/src/driver/campaign_spend_fractions_generators.py
+++ b/src/driver/campaign_spend_fractions_generators.py
@@ -15,14 +15,23 @@
 
 from itertools import cycle, islice
 
-# A dictionary of functions that maps the number of publishers p
+# A class of functions that maps the number of publishers p
 # to a list of length p.  The i-th element of the output list is
 # the campaign spend fraction at publisher i.
 
-CAMPAIGN_SPEND_FRACTIONS_GENERATORS = {
-    "all_0.2": lambda p: [0.2] * p,
-    "cyc_0.1_0.2_0.3": lambda p: list(islice(cycle([0.1, 0.2, 0.3]), p)),
-    "all_0.6": lambda p: [0.6] * p,
-    "cyc_0.4_0.8": lambda p: list(islice(cycle([0.4, 0.8]), p)),
-    "cyc_0.3_0.6_0.9": lambda p: list(islice(cycle([0.3, 0.6, 0.9]), p)),
-}
+
+class CampaignSpendFractionsGenerators:
+    def all_20(p):
+        return [0.2] * p
+
+    def cyc_10_20_30(p):
+        return list(islice(cycle([0.1, 0.2, 0.3]), p))
+
+    def all_60(p):
+        return [0.6] * p
+
+    def cyc_40_80(p):
+        return list(islice(cycle([0.4, 0.8]), p))
+
+    def cyc_30_60_90(p):
+        return list(islice(cycle([0.3, 0.6, 0.9]), p))

--- a/src/driver/m3_first_round_experimental_design.py
+++ b/src/driver/m3_first_round_experimental_design.py
@@ -22,10 +22,10 @@ from pyDOE import lhs
 from typing import Iterable
 
 from wfa_planning_evaluation_framework.driver.campaign_spend_fractions_generators import (
-    CAMPAIGN_SPEND_FRACTIONS_GENERATORS,
+    CampaignSpendFractionsGenerators,
 )
 from wfa_planning_evaluation_framework.driver.num_test_points_generators import (
-    NUM_TEST_POINTS_GENERATORS,
+    NumTestPointsGenerators,
 )
 from wfa_planning_evaluation_framework.driver.experiment_parameters import (
     ExperimentParameters,
@@ -66,8 +66,8 @@ MODELING_STRATEGIES = [
 ]
 
 CAMPAIGN_SPEND_FRACTIONS_GENERATORS = [
-    CAMPAIGN_SPEND_FRACTIONS_GENERATORS["all_0.2"],
-    CAMPAIGN_SPEND_FRACTIONS_GENERATORS["cyc_0.1_0.2_0.3"],
+    CampaignSpendFractionsGenerators.all_20,
+    CampaignSpendFractionsGenerators.cyc_10_20_30,
 ]
 
 LIQUID_LEGIONS_PARAMS = [
@@ -86,8 +86,8 @@ REPLICA_IDS = [1, 2, 3]
 MAX_FREQUENCIES = [5, 20]
 
 TEST_POINT_STRATEGIES = [
-    ("latin_hypercube", {"npoints_generator": NUM_TEST_POINTS_GENERATORS["100p"]}),
-    ("uniformly_random", {"npoints_generator": NUM_TEST_POINTS_GENERATORS["100p"]}),
+    ("latin_hypercube", {"npoints_generator": NumTestPointsGenerators.p_times_100}),
+    ("uniformly_random", {"npoints_generator": NumTestPointsGenerators.p_times_100}),
 ]
 
 LEVELS = {

--- a/src/driver/m3_first_round_experimental_design.py
+++ b/src/driver/m3_first_round_experimental_design.py
@@ -20,8 +20,13 @@ import math
 import numpy as np
 from pyDOE import lhs
 from typing import Iterable
-from itertools import cycle, islice
 
+from wfa_planning_evaluation_framework.driver.campaign_spend_fractions_generators import (
+    CAMPAIGN_SPEND_FRACTIONS_GENERATORS,
+)
+from wfa_planning_evaluation_framework.driver.num_test_points_generators import (
+    NUM_TEST_POINTS_GENERATORS,
+)
 from wfa_planning_evaluation_framework.driver.experiment_parameters import (
     ExperimentParameters,
 )
@@ -31,6 +36,7 @@ from wfa_planning_evaluation_framework.driver.modeling_strategy_descriptor impor
 from wfa_planning_evaluation_framework.simulator.modeling_strategy import (
     ModelingStrategy,
 )
+
 from wfa_planning_evaluation_framework.simulator.privacy_tracker import (
     PrivacyBudget,
 )
@@ -60,8 +66,8 @@ MODELING_STRATEGIES = [
 ]
 
 CAMPAIGN_SPEND_FRACTIONS_GENERATORS = [
-    lambda npublishers: [0.2] * npublishers,
-    lambda npublishers: list(islice(cycle([0.1, 0.2, 0.3]), npublishers)),
+    CAMPAIGN_SPEND_FRACTIONS_GENERATORS["all_0.2"],
+    CAMPAIGN_SPEND_FRACTIONS_GENERATORS["cyc_0.1_0.2_0.3"],
 ]
 
 LIQUID_LEGIONS_PARAMS = [
@@ -80,8 +86,8 @@ REPLICA_IDS = [1, 2, 3]
 MAX_FREQUENCIES = [5, 20]
 
 TEST_POINT_STRATEGIES = [
-    ("latin_hypercube", {"npoints_generator": lambda npublishers: 100 * npublishers}),
-    ("uniformly_random", {"npoints_generator": lambda npublishers: 100 * npublishers}),
+    ("latin_hypercube", {"npoints_generator": NUM_TEST_POINTS_GENERATORS["100p"]}),
+    ("uniformly_random", {"npoints_generator": NUM_TEST_POINTS_GENERATORS["100p"]}),
 ]
 
 LEVELS = {

--- a/src/driver/num_test_points_generators.py
+++ b/src/driver/num_test_points_generators.py
@@ -21,7 +21,7 @@ class NumTestPointsGenerators:
     def p_times_10(p):
         return 10 * p
 
-    def p_times_10(p):
+    def p_times_100(p):
         return 100 * p
 
     def p_sq_times_2(p):

--- a/src/driver/num_test_points_generators.py
+++ b/src/driver/num_test_points_generators.py
@@ -13,12 +13,19 @@
 # limitations under the License.
 """Functions to generate npoints in Latin/Uniform test point generataors."""
 
-# A dictionary of functions that maps the number of publishers p
+# A class of functions that maps the number of publishers p
 # to the number of testing points.
 
-NUM_TEST_POINTS_GENERATORS = {
-    "10p": lambda p: 10 * p,
-    "100p": lambda p: 100 * p,
-    "2p^2": lambda p: 2 * p ** 2,
-    "10p^2": lambda p: 10 * p ** 2,
-}
+
+class NumTestPointsGenerators:
+    def p_times_10(p):
+        return 10 * p
+
+    def p_times_10(p):
+        return 100 * p
+
+    def p_sq_times_2(p):
+        return 2 * p ** 2
+
+    def p_sq_times_10(p):
+        return 10 * p ** 2

--- a/src/driver/num_test_points_generators.py
+++ b/src/driver/num_test_points_generators.py
@@ -1,0 +1,24 @@
+# Copyright 2021 The Private Cardinality Estimation Framework Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions to generate npoints in Latin/Uniform test point generataors."""
+
+# A dictionary of functions that maps the number of publishers p
+# to the number of testing points.
+
+NUM_TEST_POINTS_GENERATORS = {
+    "10p": lambda p: 10 * p,
+    "100p": lambda p: 100 * p,
+    "2p^2": lambda p: 2 * p ** 2,
+    "10p^2": lambda p: 10 * p ** 2,
+}


### PR DESCRIPTION
Created this PR following Matthew's suggestions:
"With lambda functions in experimental configs, if we run the same experiment twice, the planning evaluation framework may not be able to detect that this is a repeat of a previous run.  That's because the lambda expression may be assigned a different address in memory, so the name assigned to the experiment may be different."