### PR TITLE
Impression minimums for Gamma-Poisson distribution

### DIFF
--- a/src/driver/single_publisher_design.py
+++ b/src/driver/single_publisher_design.py
@@ -39,7 +39,13 @@ from wfa_planning_evaluation_framework.driver.trial_descriptor import (
     TrialDescriptor,
 )
 
-MODELING_STRATEGIES = ["goerg", "gamma_poisson"]
+MODELING_STRATEGIES = [
+    ("goerg", {}),
+    ("gamma_poisson", {}),
+    ("gamma_poisson", {"extrapolation_multiplier": 2.0}),
+    ("gamma_poisson", {"extrapolation_multiplier": 3.0}),
+]
+
 CAMPAIGN_SPEND_FRACTIONS = list(np.arange(1, 20) * 0.05)
 LIQUID_LEGIONS_DECAY_RATES = [10, 12, 15]
 LIQUID_LEGIONS_SKETCH_SIZES = [50_000, 100_000]

--- a/src/models/gamma_poisson_model.py
+++ b/src/models/gamma_poisson_model.py
@@ -334,6 +334,9 @@ class GammaPoissonModel(ReachCurve):
           chi^2 distance between the actual and expected histograms, plus
           a term for weighting the difference in 1+ reach.
         """
+        if alpha <= 0 or beta <= 0 or N <= 0:
+            return np.sum(np.array(h) ** 2)
+
         # Estimate total number of potential impressions
         Imax = self._expected_impressions(N, alpha, beta)
         if Imax <= I:

--- a/src/models/gamma_poisson_model.py
+++ b/src/models/gamma_poisson_model.py
@@ -125,7 +125,11 @@ class GammaPoissonModel(ReachCurve):
             be achieved.
           extrapolation_multiplier:  Int.  If specified, then a penalty term is
             introduced that penalizes models where the expected number of impressions
-            is less than extrapolation_multiplier * data[0].impressions[0].
+            in the inventory is less than extrapolation_multiplier times the
+            observed number of impressions.  Thus, if the extrapolation_multiplier
+            is 2, then optimizer prefers models where the number of impressions in
+            the inventory is at least twice the number of impressions that were
+            observed in the campaign.
         """
         if len(data) != 1:
             raise ValueError("Exactly one ReachPoint must be specified")

--- a/src/models/tests/gamma_poisson_model_test.py
+++ b/src/models/tests/gamma_poisson_model_test.py
@@ -219,17 +219,23 @@ class GammaPoissonModelTest(absltest.TestCase):
         self.assertAlmostEqual(gpm.by_spend([300]).reach(1), 10000.0, delta=0.1)
 
     def test_fit_histogram_chi2_distance_with_extrapolation(self):
-        # The following point corresponds to
+        # The following point is generated under these parameter settings
         #  I, Imax, N, alpha0, beta0 = 5000, 30000, 10000, 1.0, 2.0
         # This represents a distribution with mean = 3 and variance = 6.
+        #
+        # The last few values in the k+ reach histogram are set to 0 to force
+        # the optimizer to choose a suboptimal value for N and Imax.  This
+        # simulates the effect of adding differentially private noise to the
+        # frequency buckets.  The true expected frequency histogram is
+        #   [3745,  933,  230,   55,   12,    2,    0,    0,    0,    0]
         kplus_actual = [3745, 933, 230, 0, 0, 0, 0, 0, 0, 0]
         rp = ReachPoint([5000], kplus_actual)
         gpm = GammaPoissonModel([rp])
         Imax, _, _, _ = gpm._fit_histogram_chi2_distance(rp, nstarting_points=1)
         gpm2 = GammaPoissonModel([rp], extrapolation_multiplier=4.0)
         Imax2, _, _, _ = gpm2._fit_histogram_chi2_distance(rp, nstarting_points=1)
-        self.assertAlmostEqual(Imax, 16500, delta=100)
-        self.assertAlmostEqual(Imax2, 20000, delta=100)
+        self.assertAlmostEqual(Imax, 16540, delta=1)
+        self.assertAlmostEqual(Imax2, 20000, delta=1)
 
 
 if __name__ == "__main__":

--- a/src/models/tests/gamma_poisson_model_test.py
+++ b/src/models/tests/gamma_poisson_model_test.py
@@ -218,6 +218,19 @@ class GammaPoissonModelTest(absltest.TestCase):
         self.assertAlmostEqual(gpm.by_impressions([30000]).reach(1), 10000.0, delta=0.1)
         self.assertAlmostEqual(gpm.by_spend([300]).reach(1), 10000.0, delta=0.1)
 
+    def test_fit_histogram_chi2_distance_with_extrapolation(self):
+        # The following point corresponds to
+        #  I, Imax, N, alpha0, beta0 = 5000, 30000, 10000, 1.0, 2.0
+        # This represents a distribution with mean = 3 and variance = 6.
+        kplus_actual = [3745, 933, 230, 0, 0, 0, 0, 0, 0, 0]
+        rp = ReachPoint([5000], kplus_actual)
+        gpm = GammaPoissonModel([rp])
+        Imax, _, _, _ = gpm._fit_histogram_chi2_distance(rp, nstarting_points=1)
+        gpm2 = GammaPoissonModel([rp], extrapolation_multiplier=4.0)
+        Imax2, _, _, _ = gpm2._fit_histogram_chi2_distance(rp, nstarting_points=1)
+        self.assertAlmostEqual(Imax, 16500, delta=100)
+        self.assertAlmostEqual(Imax2, 20000, delta=100)
+
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
When fitting noisy data, the Gamma-Poisson distribution tends to underestimate the true audience size.  This PR adds a penalty term to the objective function that penalizes parameter settings where the impression count is less than a specified factor times the observed impression count.
