### PR TITLE
Fix tests broken by #87

### DIFF
--- a/src/simulator/privacy_tracker.py
+++ b/src/simulator/privacy_tracker.py
@@ -115,8 +115,8 @@ class PrivacyTracker:
         """
         # Take maximum privacy budget spent across all buckets. For this, it
         # suffices to take the starting points of the buckets.
-        max_epsilon = 0
-        max_delta = 0
+        max_epsilon = 0.0
+        max_delta = 0.0
         for sampling_bucket_ in self._sampling_buckets_starting_points:
             consumed_budget = self.privacy_consumption_for_sampling_bucket(
                 sampling_bucket_
@@ -132,8 +132,8 @@ class PrivacyTracker:
         basic composition rule.  This will be expanded in the future
         to support advanced composition (see TODO #1 above).
         """
-        epsilon_sum = 0
-        delta_sum = 0
+        epsilon_sum = 0.0
+        delta_sum = 0.0
         for event in self._noising_events:
             if event.sampling_buckets.contains(sampling_bucket):
                 epsilon_sum += event.budget.epsilon

--- a/src/simulator/tests/halo_simulator_test.py
+++ b/src/simulator/tests/halo_simulator_test.py
@@ -196,8 +196,8 @@ class HaloSimulatorTest(parameterized.TestCase):
         expected_reach_points = []
 
         self.assertEqual(expected_reach_points, reach_points)
-        self.assertEqual(halo.privacy_tracker._epsilon_sum, 0)
-        self.assertEqual(halo.privacy_tracker._delta_sum, 0)
+        self.assertEqual(halo.privacy_tracker.privacy_consumption.epsilon, 0)
+        self.assertEqual(halo.privacy_tracker.privacy_consumption.delta, 0)
         self.assertEqual(len(halo.privacy_tracker._noising_events), 0)
 
     @parameterized.named_parameters(
@@ -347,12 +347,12 @@ class HaloSimulatorTest(parameterized.TestCase):
         ]
 
         self.assertEqual(
-            halo.privacy_tracker._epsilon_sum,
+            halo.privacy_tracker.privacy_consumption.epsilon,
             expected_noise_event_primitive_regions.budget.epsilon
             + expected_noise_event_cardinality.budget.epsilon,
         )
         self.assertEqual(
-            halo.privacy_tracker._delta_sum,
+            halo.privacy_tracker.privacy_consumption.delta,
             expected_noise_event_primitive_regions.budget.delta
             + expected_noise_event_cardinality.budget.delta,
         )
@@ -572,10 +572,10 @@ class HaloSimulatorTest(parameterized.TestCase):
 
         self.assertEqual(noised_regions, expected_regions)
         self.assertEqual(
-            halo.privacy_tracker._epsilon_sum, budget.epsilon * privacy_budget_split
+            halo.privacy_tracker.privacy_consumption.epsilon, budget.epsilon * privacy_budget_split
         )
         self.assertEqual(
-            halo.privacy_tracker._delta_sum, budget.delta * privacy_budget_split
+            halo.privacy_tracker.privacy_consumption.delta, budget.delta * privacy_budget_split
         )
         self.assertEqual(len(halo.privacy_tracker._noising_events), 1)
         self.assertEqual(
@@ -653,10 +653,10 @@ class HaloSimulatorTest(parameterized.TestCase):
         self.assertEqual(scaled_regions, expected)
 
         self.assertEqual(
-            halo.privacy_tracker._epsilon_sum, budget.epsilon * privacy_budget_split
+            halo.privacy_tracker.privacy_consumption.epsilon, budget.epsilon * privacy_budget_split
         )
         self.assertEqual(
-            halo.privacy_tracker._delta_sum, budget.delta * privacy_budget_split
+            halo.privacy_tracker.privacy_consumption.delta, budget.delta * privacy_budget_split
         )
         self.assertEqual(len(halo.privacy_tracker._noising_events), 1)
         self.assertEqual(


### PR DESCRIPTION
See [Issue #94](https://github.com/world-federation-of-advertisers/planning-evaluation-framework/issues/94). Note that the ExperimentalTrialTest was broken due to type inference to int64 of dataframe for value 0; the other tests were broken because they access _epsilon_sum and _delta_sum which were removed in #87.