### PR TITLE
Compute kreach and knreach using broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ to be spent for this impression to be shown.
 A Data Design can be synthetic, or it can represent actual publisher data.
 Synthetic data designs can be generated using the program
 `data_generators/synthetic_data_generator.py`. Alternatively, if you have other
-data available in your organization, you can construct your own data design. 
+data available in your organization, you can construct your own data design.
 
 An Experimental Design specifies the modeling strategies that will be
 evaluated and the parameters that will be used for evaluation. An
@@ -52,7 +52,7 @@ is subdivided into Experiments, which are further broken down into
 Trials. An Experiment consists of a collection of modeling strategies
 and model parameters that are run against a single Dataset. A Trial
 consists of simulating the outcome of one modeling strategy using one
-Dataset and one set of parameter values. 
+Dataset and one set of parameter values.
 
 Once a Data Design and an Experimental Design have been specified, the Evaluator
 can be used to run simulations of the experimental design versus the data
@@ -116,7 +116,7 @@ export PYTHONPATH
 Then run `source path_to/.bash_profile` or `source path_to/.zshrc_` in the terminal.
 
 2. Create a Symlink named `wfa_planning_evaluation_framework` at the directory which contains your planning-evaluation-framework repo with command:
-    
+
 ```
 ln -s path_to/planning-evaluation-framework/src/ dir_which_contains_planning_evaluation_framework_repo/wfa_planning_evaluation_framework
 ```
@@ -142,7 +142,7 @@ that can be used to generate synthetic data sets:
 * `m3_data_design.py`: The data design that is used for validating the M3 model.
 
 In this example, we will generate data for the single publisher models and then analyze the
-performance of these models.  The next command invokes the synthetic data generator.  
+performance of these models.  The next command invokes the synthetic data generator.
 
 
 ```
@@ -179,7 +179,7 @@ python3 driver/experiment_driver.py -- \
   --cores=0
 ```
 
-Setting `cores=0` enables multithreading on all available cores.  
+Setting `cores=0` enables multithreading on all available cores.
 
 In addition, you may use Apache Beam to evaluate the Experiments in two different modes -- direct runner and Dataflow runner. For the direct runner mode, use multi-processing with the execution command:
 
@@ -241,10 +241,9 @@ black file1.py file2.py ...
 
 #### Steps for merging a pull request
 
-1. `git checkout main` and `git pull` to get the latest changes. 
-2. `git checkout target_branch`. Make sure it is the latest. 
-3. `git rebase main`. Resolve conflicts if there is any. 
+1. `git checkout main` and `git pull` to get the latest changes.
+2. `git checkout target_branch`. Make sure it is the latest.
+3. `git rebase main`. Resolve conflicts if there is any.
 4. Run all unit tests with command `find . | egrep ".*tests/.*.py" | xargs -n 1 python3`
-5. If everything is okay, `git push -f` to push your rebased branch to the server. 
+5. If everything is okay, `git push -f` to push your rebased branch to the server.
 6. Go to the [web interface](https://github.com/world-federation-of-advertisers/planning-evaluation-framework) and click `merge pull request`.
-

--- a/src/driver/experiment_driver.py
+++ b/src/driver/experiment_driver.py
@@ -193,7 +193,7 @@ class ExperimentDriver:
             use_apache_beam=use_apache_beam,
             pipeline_options=pipeline_options,
         )
-        filesystem.write_text(self._output_file, result.to_csv(index=False))
+        filesystem.write_text(self._output_file, result.to_csv(na_rep="NaN", index=False))
 
         return result
 

--- a/src/driver/experimental_design.py
+++ b/src/driver/experimental_design.py
@@ -169,7 +169,7 @@ class ExperimentalDesign:
                 | "Write combined result"
                 >> beam.Map(
                     lambda df: self._filesystem.write_text(
-                        result_path, df.to_csv(index=False)
+                        result_path, df.to_csv(na_rep="NaN", index=False)
                     )
                 )
             )

--- a/src/driver/experimental_trial.py
+++ b/src/driver/experimental_trial.py
@@ -215,7 +215,7 @@ class ExperimentalTrial:
                 logging.vlog(1, f"Trial   {self._trial_descriptor}")
             logging.vlog(1, f"Modeling failure: {inst}")
             logging.vlog(2, traceback.format_exc())
-            metrics = aggregate_on_exception(inst)
+            metrics = aggregate_on_exception(traceback.format_exc())
             if self._analysis_type == SINGLE_PUB_ANALYSIS:
                 single_publisher_dataframe = (
                     self._single_publisher_fractions_dataframe_on_exception(
@@ -239,7 +239,9 @@ class ExperimentalTrial:
         filesystem.mkdir(
             filesystem.parent(trial_results_path), parents=True, exist_ok=True
         )
-        filesystem.write_text(trial_results_path, result.to_csv(na_rep="NaN", index=False))
+        filesystem.write_text(
+            trial_results_path, result.to_csv(na_rep="NaN", index=False)
+        )
         filesystem.unlink(pending_path, missing_ok=True)
 
         return result

--- a/src/driver/experimental_trial.py
+++ b/src/driver/experimental_trial.py
@@ -239,7 +239,7 @@ class ExperimentalTrial:
         filesystem.mkdir(
             filesystem.parent(trial_results_path), parents=True, exist_ok=True
         )
-        filesystem.write_text(trial_results_path, result.to_csv(index=False))
+        filesystem.write_text(trial_results_path, result.to_csv(index=False, na_rep="NaN"))
         filesystem.unlink(pending_path, missing_ok=True)
 
         return result

--- a/src/driver/experimental_trial.py
+++ b/src/driver/experimental_trial.py
@@ -218,7 +218,9 @@ class ExperimentalTrial:
             metrics = aggregate_on_exception(inst)
             if self._analysis_type == SINGLE_PUB_ANALYSIS:
                 single_publisher_dataframe = (
-                    self._single_publisher_fractions_dataframe_on_exception(max_frequency)
+                    self._single_publisher_fractions_dataframe_on_exception(
+                        max_frequency
+                    )
                 )
 
         independent_vars = self._make_independent_vars_dataframe()
@@ -338,15 +340,21 @@ class ExperimentalTrial:
         results["max_nonzero_frequency_from_halo"] = [
             max(
                 [(i + 1) for i, f in enumerate(training_point._kplus_reaches) if f != 0]
+                + [0]
             )
         ]
         data_point = halo.true_reach_by_spend(halo.campaign_spends, max_frequency)
         results["max_nonzero_frequency_from_data"] = [
-            max([(i + 1) for i, f in enumerate(data_point._kplus_reaches) if f != 0])
+            max(
+                [(i + 1) for i, f in enumerate(data_point._kplus_reaches) if f != 0]
+                + [0]
+            )
         ]
         return pd.DataFrame(results)
 
-    def _single_publisher_fractions_dataframe_on_exception(self, max_frequency) -> pd.DataFrame:
+    def _single_publisher_fractions_dataframe_on_exception(
+        self, max_frequency
+    ) -> pd.DataFrame:
         results = {}
         for r in SINGLE_PUBLISHER_FRACTIONS:
             column_name = f"relative_error_at_{int(r*100):03d}"

--- a/src/driver/experimental_trial.py
+++ b/src/driver/experimental_trial.py
@@ -339,19 +339,26 @@ class ExperimentalTrial:
         # Also, record the maximum frequency in the actual data and the
         # data produced by Halo.
         training_point = reach_surface._data[0]
-        results["max_nonzero_frequency_from_halo"] = [
-            max(
-                [(i + 1) for i, f in enumerate(training_point._kplus_reaches) if f != 0]
-                + [0]
-            )
-        ]
+        results["max_nonzero_frequency_from_halo"] = (
+            [
+                max(
+                    [
+                        (i + 1)
+                        for i, f in enumerate(training_point._kplus_reaches)
+                        if f != 0
+                    ]
+                )
+            ]
+            if training_point._kplus_reaches
+            else [0]
+        )
         data_point = halo.true_reach_by_spend(halo.campaign_spends, max_frequency)
-        results["max_nonzero_frequency_from_data"] = [
-            max(
-                [(i + 1) for i, f in enumerate(data_point._kplus_reaches) if f != 0]
-                + [0]
-            )
-        ]
+        results["max_nonzero_frequency_from_data"] = (
+            [max([(i + 1) for i, f in enumerate(data_point._kplus_reaches) if f != 0])]
+            if data_point._kplus_reaches
+            else [0]
+        )
+
         return pd.DataFrame(results)
 
     def _single_publisher_fractions_dataframe_on_exception(

--- a/src/driver/experimental_trial.py
+++ b/src/driver/experimental_trial.py
@@ -239,7 +239,7 @@ class ExperimentalTrial:
         filesystem.mkdir(
             filesystem.parent(trial_results_path), parents=True, exist_ok=True
         )
-        filesystem.write_text(trial_results_path, result.to_csv(index=False, na_rep="NaN"))
+        filesystem.write_text(trial_results_path, result.to_csv(na_rep="NaN", index=False))
         filesystem.unlink(pending_path, missing_ok=True)
 
         return result

--- a/src/driver/test_point_aggregator.py
+++ b/src/driver/test_point_aggregator.py
@@ -140,7 +140,7 @@ def aggregate(
     Returns:
       A single row DataFrame representing the values of the statistics listed in keys.
     """
-    stats = {"model_succeeded": [1], "model_exception": [""]}
+    stats = {"model_succeeded": [1], "model_exception": ["None"]}
     for key in AGGREGATORS:
         stats[key] = [AGGREGATORS[key](true_reach, simulated_reach)]
     return pd.DataFrame(data=stats)

--- a/src/driver/test_point_aggregator.py
+++ b/src/driver/test_point_aggregator.py
@@ -146,15 +146,16 @@ def aggregate(
     return pd.DataFrame(data=stats)
 
 
-def aggregate_on_exception(inst: Exception) -> pd.DataFrame:
+def aggregate_on_exception(debug_msg: str) -> pd.DataFrame:
     """Returns a DataFrame of the same shape as aggregate but for case of an exception.
 
     Args:
-      inst:  The exception instance that was generated in the modeling attempt.
+      debug_msg:  The message for debugging the cause of the exception that was
+        generated in the modeling attempt.
     Returns:
       A single row DataFrame of NAs with columns being the statistics listed in keys.
     """
-    stats = {"model_succeeded": [0], "model_exception": [str(inst)]}
+    stats = {"model_succeeded": [0], "model_exception": [debug_msg]}
     for key in AGGREGATORS:
         stats[key] = [np.NaN]
     return pd.DataFrame(data=stats)

--- a/src/driver/tests/experiment_driver_test.py
+++ b/src/driver/tests/experiment_driver_test.py
@@ -65,7 +65,7 @@ def fake_evaluate_all_trials_using_apache_beam(self, pipeline_options, result_pa
         result_path = client.CloudPath(result_path)
 
     num_trials = len(self._all_trials)
-    df = pd.DataFrame({"col": [i for i in range(num_trials)]})
+    df = pd.DataFrame({"col": list(range(num_trials))})
     df.to_csv(result_path, index=False)
 
 

--- a/src/driver/tests/experimental_trial_test.py
+++ b/src/driver/tests/experimental_trial_test.py
@@ -355,9 +355,9 @@ class ExperimentalTrialTest(absltest.TestCase):
             self.assertEqual(result["replica_id"][0], 3)
             self.assertEqual(result["privacy_budget_epsilon"][0], 1.0)
             self.assertEqual(result["model_succeeded"][0], 0)
-            self.assertEqual(
-                result["model_exception"][0],
-                "Cannot fit Goerg model when impressions <= reach.",
+            self.assertTrue(
+                "Cannot fit Goerg model when impressions <= reach."
+                in result["model_exception"][0]
             )
 
     def test_evaluate_singe_publisher_model_with_exception(self):

--- a/src/driver/tests/experimental_trial_test.py
+++ b/src/driver/tests/experimental_trial_test.py
@@ -319,7 +319,7 @@ class ExperimentalTrialTest(absltest.TestCase):
             self.assertEqual(result["privacy_budget_epsilon"][0], 1.0)
             self.assertEqual(result["npoints"][0], 1)
             self.assertEqual(result["model_succeeded"][0], 1)
-            self.assertEqual(result["model_exception"][0], "")
+            self.assertEqual(result["model_exception"][0], "None")
 
     def test_evaluate_when_there_is_a_modeling_exception(self):
         with TemporaryDirectory() as d:
@@ -356,8 +356,8 @@ class ExperimentalTrialTest(absltest.TestCase):
             self.assertEqual(result["privacy_budget_epsilon"][0], 1.0)
             self.assertEqual(result["model_succeeded"][0], 0)
             self.assertIn(
-                "Cannot fit Goerg model when impressions <= reach.", 
-                result["model_exception"][0]
+                "Cannot fit Goerg model when impressions <= reach.",
+                result["model_exception"][0],
             )
 
     def test_evaluate_singe_publisher_model_with_exception(self):

--- a/src/driver/tests/experimental_trial_test.py
+++ b/src/driver/tests/experimental_trial_test.py
@@ -355,9 +355,9 @@ class ExperimentalTrialTest(absltest.TestCase):
             self.assertEqual(result["replica_id"][0], 3)
             self.assertEqual(result["privacy_budget_epsilon"][0], 1.0)
             self.assertEqual(result["model_succeeded"][0], 0)
-            self.assertTrue(
-                "Cannot fit Goerg model when impressions <= reach."
-                in result["model_exception"][0]
+            self.assertIn(
+                "Cannot fit Goerg model when impressions <= reach.", 
+                result["model_exception"][0]
             )
 
     def test_evaluate_singe_publisher_model_with_exception(self):

--- a/src/models/gamma_poisson_model.py
+++ b/src/models/gamma_poisson_model.py
@@ -149,6 +149,8 @@ class GammaPoissonModel(ReachCurve):
         else:
             self._cpi = None
 
+        self.binom_dist = scipy.stats._discrete_distns.binom_gen(name="binom_dist")
+
     def _logpmf(self, n, alpha, beta):
         """Log of the PMF of the shifted Gamma-Poisson distribution.
 
@@ -187,8 +189,7 @@ class GammaPoissonModel(ReachCurve):
           (C, M) ndarray. Probability that a randomly chosen user will have an
           inventory of n impressions, of which k are shown.
         """
-        binom_dist = scipy.stats._discrete_distns.binom_gen(name="binom_dist")
-        kprob = binom_dist.logpmf(
+        kprob = self.binom_dist.logpmf(
             k.reshape((-1, 1)), n.reshape((1, -1)), I / Imax
         )  # shape: (C, M)
         gp_logpmf = self._logpmf(n, alpha, beta)  # shape: (M, )

--- a/src/models/gamma_poisson_model.py
+++ b/src/models/gamma_poisson_model.py
@@ -167,20 +167,6 @@ class GammaPoissonModel(ReachCurve):
         """
         return scipy.stats.nbinom.logpmf(n - 1, alpha, 1.0 / (1.0 + beta))
 
-    def _binom_logpmf(self, k, n, p):
-        """
-        Args:
-          k: (C, ) ndarray. Numbers of impressions that were seen by the user.
-          n: (M, ) ndarray. Values at which the distribution is to be evaluated.
-          p: float. The probability of one success in the binomial distribution
-        Returns:
-          (C, M) ndarray of log of the probability mass function of binomial
-            distribution.
-        """
-        k = k.reshape((-1, 1))
-        n = n.reshape((1, -1))
-        return scipy.stats.binom.logpmf(k, n, p)
-
     def _knreach(self, k, n, I, Imax, alpha, beta):
         """Probability that a random user has n impressions of which k are shown.
 
@@ -201,8 +187,11 @@ class GammaPoissonModel(ReachCurve):
           (C, M) ndarray. Probability that a randomly chosen user will have an
           inventory of n impressions, of which k are shown.
         """
-        kprob = self._binom_logpmf(k, n, I / Imax)  # shape: (C, M)
+        kprob = scipy.stats.binom.logpmf(
+            k.reshape((-1, 1)), n.reshape((1, -1)), I / Imax
+        )  # shape: (C, M)
         gp_logpmf = self._logpmf(n, alpha, beta)  # shape: (M, )
+
         return np.exp(kprob + gp_logpmf)
 
     def _kreach(self, k, I, Imax, alpha, beta):

--- a/src/models/gamma_poisson_model.py
+++ b/src/models/gamma_poisson_model.py
@@ -187,7 +187,8 @@ class GammaPoissonModel(ReachCurve):
           (C, M) ndarray. Probability that a randomly chosen user will have an
           inventory of n impressions, of which k are shown.
         """
-        kprob = scipy.stats.binom.logpmf(
+        binom_dist = scipy.stats._discrete_distns.binom_gen(name="binom_dist")
+        kprob = binom_dist.logpmf(
             k.reshape((-1, 1)), n.reshape((1, -1)), I / Imax
         )  # shape: (C, M)
         gp_logpmf = self._logpmf(n, alpha, beta)  # shape: (M, )

--- a/src/models/kinflated_gamma_poisson_model.py
+++ b/src/models/kinflated_gamma_poisson_model.py
@@ -134,7 +134,8 @@ class KInflatedGammaPoissonDistribution:
           (C, M) ndarray. Probability that a randomly chosen user will have an
           inventory of n impressions, of which k are shown.
         """
-        kprob = scipy.stats.binom.pmf(k.reshape(-1, 1), n.reshape(1, -1), p)
+        binom_dist = scipy.stats._discrete_distns.binom_gen(name="binom_dist")
+        kprob = binom_dist.pmf(k.reshape(-1, 1), n.reshape(1, -1), p)
         return kprob * self.pmf(n)
 
     def kreach(self, k: Iterable[float], p: float) -> npt.ArrayLike:

--- a/src/models/kinflated_gamma_poisson_model.py
+++ b/src/models/kinflated_gamma_poisson_model.py
@@ -51,7 +51,7 @@ class KInflatedGammaPoissonDistribution:
     """
 
     def __init__(self, alpha: float, beta: float, a: List[float]):
-        """k-Inflated Gamma-Poisson with parameters alpha, beta, a. """
+        """k-Inflated Gamma-Poisson with parameters alpha, beta, a."""
         if sum(a) > 1.0:
             # In theory, it should be an error to create a distribution where
             # the values of sum to a value > 1, but in practice the easiest
@@ -305,7 +305,7 @@ class KInflatedGammaPoissonModel(ReachCurve):
         obj = np.sum((hbar - h) ** 2 / (hbar + 1e-6))
 
         if np.isnan(obj):
-            logging.vlog(2, f"alpha {alpha} beta {beta} N {N} Imax {Imax}")
+            logging.vlog(2, f"alpha {dist._alpha} beta {dist._beta} N {N} Imax {Imax}")
             logging.vlog(2, f"h    {h}")
             logging.vlog(2, f"hbar {hbar}")
             raise RuntimeError("Invalid value of objective function")

--- a/src/models/kinflated_gamma_poisson_model.py
+++ b/src/models/kinflated_gamma_poisson_model.py
@@ -80,6 +80,8 @@ class KInflatedGammaPoissonDistribution:
         # Force the series to sum to 1.
         self._pmf[-1] = 1.0 - np.sum(self._pmf[:-1])
 
+        self.binom_dist = scipy.stats._discrete_distns.binom_gen(name="binom_dist")
+
     def _gamma_poisson_pmf(
         self, n: Union[int, Iterable[int]], alpha: float, beta: float
     ) -> Union[float, npt.ArrayLike]:
@@ -134,8 +136,7 @@ class KInflatedGammaPoissonDistribution:
           (C, M) ndarray. Probability that a randomly chosen user will have an
           inventory of n impressions, of which k are shown.
         """
-        binom_dist = scipy.stats._discrete_distns.binom_gen(name="binom_dist")
-        kprob = binom_dist.pmf(k.reshape(-1, 1), n.reshape(1, -1), p)
+        kprob = self.binom_dist.pmf(k.reshape(-1, 1), n.reshape(1, -1), p)
         return kprob * self.pmf(n)
 
     def kreach(self, k: Iterable[float], p: float) -> npt.ArrayLike:

--- a/src/models/tests/gamma_poisson_model_test.py
+++ b/src/models/tests/gamma_poisson_model_test.py
@@ -92,6 +92,14 @@ class GammaPoissonModelTest(absltest.TestCase):
         self.assertAlmostEqual(gpm._kreach([0, 1, 2], 1, 3, 1, 1)[1], 3 / 8)
         self.assertAlmostEqual(gpm._kreach([0, 1, 2], 1, 3, 1, 1)[2], 3 / 32)
 
+    def test_kreach_invalid_k(self):
+        gpm = GammaPoissonModel([ReachPoint([20], [10])])
+        exception_msg = (
+            "Values in k have to be consecutively from min_freq to max_freq."
+        )
+        with self.assertRaises(RuntimeError, msg=exception_msg):
+            gpm._kreach([0, 4, 1, 2, 3], 1, 2, 1, 1)
+
     def test_expected_impressions(self):
         gpm = GammaPoissonModel([ReachPoint([20], [10])])
         self.assertAlmostEqual(gpm._expected_impressions(1, 1, 1), 2.0)

--- a/src/models/tests/gamma_poisson_model_test.py
+++ b/src/models/tests/gamma_poisson_model_test.py
@@ -63,18 +63,24 @@ class GammaPoissonModelTest(absltest.TestCase):
 
     def test_knreach(self):
         gpm = GammaPoissonModel([ReachPoint([20], [10])])
-        self.assertAlmostEqual(gpm._knreach(1, 1, 1, 2, 1.0, 1.0), 0.25)
-        self.assertAlmostEqual(gpm._knreach(2, 1, 1, 2, 1.0, 1.0), 0)
-        self.assertAlmostEqual(gpm._knreach(1, 1, 1, 2, 1.0, 2.0), 1.0 / 6.0)
-        self.assertAlmostEqual(gpm._knreach(1, np.array([1]), 1, 2, 1.0, 1.0)[0], 1 / 4)
         self.assertAlmostEqual(
-            gpm._knreach(1, np.array([1, 2]), 1, 2, 1.0, 1.0)[0], 1 / 4
+            gpm._knreach(np.array([2]), np.array([1]), 1, 2, 1.0, 1.0)[0, 0], 0
         )
         self.assertAlmostEqual(
-            gpm._knreach(1, np.array([1, 2]), 1, 2, 1.0, 1.0)[1], 1 / 8
+            gpm._knreach(np.array([1]), np.array([1]), 1, 2, 1.0, 2.0)[0, 0], 1.0 / 6.0
         )
         self.assertAlmostEqual(
-            gpm._knreach(1, 3, 1, 3, 1.0, 1.0), 3 * (1 / 3) * (2 / 3) ** 2 * (1 / 8)
+            gpm._knreach(np.array([1]), np.array([1]), 1, 2, 1.0, 1.0)[0, 0], 1 / 4
+        )
+        self.assertAlmostEqual(
+            gpm._knreach(np.array([1]), np.array([1, 2]), 1, 2, 1.0, 1.0)[0, 0], 1 / 4
+        )
+        self.assertAlmostEqual(
+            gpm._knreach(np.array([1]), np.array([1, 2]), 1, 2, 1.0, 1.0)[0, 1], 1 / 8
+        )
+        self.assertAlmostEqual(
+            gpm._knreach(np.array([1]), np.array([3]), 1, 3, 1.0, 1.0)[0, 0],
+            3 * (1 / 3) * (2 / 3) ** 2 * (1 / 8),
         )
 
     def test_kreach(self):

--- a/src/models/tests/kinflated_gamma_poisson_test.py
+++ b/src/models/tests/kinflated_gamma_poisson_test.py
@@ -117,6 +117,14 @@ class KInflatedGammaPoissonModelTest(absltest.TestCase):
         self.assertAlmostEqual(dist.kreach([0, 1, 2], 1 / 3)[1], 3 / 8)
         self.assertAlmostEqual(dist.kreach([0, 1, 2], 1 / 3)[2], 3 / 32)
 
+    def test_kreach_invalid_k(self):
+        dist = KInflatedGammaPoissonDistribution(1.0, 1.0, [])
+        exception_msg = (
+            "Values in k have to be consecutively from min_freq to max_freq."
+        )
+        with self.assertRaises(RuntimeError, msg=exception_msg):
+            dist.kreach([0, 2, 1], 0.5)
+
     def test_expected_value(self):
         dist1 = KInflatedGammaPoissonDistribution(1.0, 1.0, [])
         self.assertAlmostEqual(dist1.expected_value(), 2.0)

--- a/src/models/tests/kinflated_gamma_poisson_test.py
+++ b/src/models/tests/kinflated_gamma_poisson_test.py
@@ -90,14 +90,22 @@ class KInflatedGammaPoissonModelTest(absltest.TestCase):
 
     def test_knreach_no_inflation(self):
         dist = KInflatedGammaPoissonDistribution(1.0, 1.0, [])
-        self.assertAlmostEqual(dist.knreach(1, 1, 0.5), 0.25)
-        self.assertAlmostEqual(dist.knreach(2, 1, 0.5), 0)
-        self.assertAlmostEqual(dist.knreach(1, 1, 0.5), 1.0 / 4.0)
-        self.assertAlmostEqual(dist.knreach(1, np.array([1]), 0.5)[0], 1 / 4)
-        self.assertAlmostEqual(dist.knreach(1, np.array([1, 2]), 0.5)[0], 1 / 4)
-        self.assertAlmostEqual(dist.knreach(1, np.array([1, 2]), 0.5)[1], 1 / 8)
+        self.assertAlmostEqual(dist.knreach(np.array([2]), np.array([1]), 0.5)[0, 0], 0)
         self.assertAlmostEqual(
-            dist.knreach(1, 3, 1 / 3), 3 * (1 / 3) * (2 / 3) ** 2 * (1 / 8)
+            dist.knreach(np.array([1]), np.array([1]), 0.5)[0, 0], 1.0 / 4.0
+        )
+        self.assertAlmostEqual(
+            dist.knreach(np.array([1]), np.array([1]), 0.5)[0, 0], 1 / 4
+        )
+        self.assertAlmostEqual(
+            dist.knreach(np.array([1]), np.array([1, 2]), 0.5)[0, 0], 1 / 4
+        )
+        self.assertAlmostEqual(
+            dist.knreach(np.array([1]), np.array([1, 2]), 0.5)[0, 1], 1 / 8
+        )
+        self.assertAlmostEqual(
+            dist.knreach(np.array([1]), np.array([3]), 1 / 3)[0, 0],
+            3 * (1 / 3) * (2 / 3) ** 2 * (1 / 8),
         )
 
     def test_kreach_no_inflation(self):


### PR DESCRIPTION
The code in `knreach` was not thread-safe and causing concurrency issue when executed with multi-threading. The root cause is that `scipy.stats.binom` is an object, so within the same interpreter, all the threads are using the same `scipy.stats.binom` object. The solution proposed in this PR is to create a new Scipy binom object every time we need to use binomial distribution.

In addition to the threading issue, we utilize broadcasting in Numpy to speed up the computation in `knreach`. The function is twice faster in the test.

Additional to the two main changes, this PR also includes several bug-fixes and modifications:
1. Trailing spaces in README
2. Use na_rep="NaN" in “to_csv” for missing data representation.
3. Using traceback message as the model exception message
4. Avoid empty list as an argument in max()
5. Use "None" when there is no model exception
