### PR TITLE
Part 1 of Dirac mixture model: the UnivariateMixedPoissonOptimizer class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ scipy==1.6.2
 seaborn==0.9.0
 lxml==4.5.2
 cvxopt==1.2.6
-cvxpy==1.1.18
+cvxpy>=1.1.18
 dp-accounting==0.0.1
 tqdm>=4.47.0
 fsspec==2021.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ scipy==1.6.2
 seaborn==0.9.0
 lxml==4.5.2
 cvxopt==1.2.6
-cvxpy==1.1.12
+cvxpy==1.1.18
 dp-accounting==0.0.1
 tqdm>=4.47.0
 fsspec==2021.7.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ REQUIRED = [
     "scipy==1.6.2",
     "lxml==4.5.2",
     "cvxopt==1.2.6",
-    "cvxpy==1.1.12",
+    "cvxpy>=1.1.18",
     "dp-accounting==0.0.1",
     "pandas>=1.2.5",
     "typing-extensions==3.10.0.2",

--- a/src/models/dirac_mixture_single_publisher_model.py
+++ b/src/models/dirac_mixture_single_publisher_model.py
@@ -253,7 +253,7 @@ class UnivariateMixedPoissonOptimizer:
         # Note: ECOS is available in C.  SCS available in C/C++.  But they are
         # both unavailable in Java.
         try:
-            problem.solve()  # The default solver is ECOS
+            problem.solve(solver=cp.ECOS)
         except cp.SolverError:
             problem.solve(solver=cp.SCS)
         return ws.value

--- a/src/models/dirac_mixture_single_publisher_model.py
+++ b/src/models/dirac_mixture_single_publisher_model.py
@@ -1,0 +1,235 @@
+# Copyright 2021 The Private Cardinality Estimation Framework Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dirac mixture single publisher model."""
+
+import numpy as np
+import cvxpy as cp
+from scipy import stats
+from typing import List, Callable
+from wfa_planning_evaluation_framework.models.reach_point import ReachPoint
+from wfa_planning_evaluation_framework.models.reach_curve import ReachCurve
+
+
+class UnivariateMixedPoissonOptimizer:
+    """Fit an univariate mixed Poisson distribution on a frequency histogram.
+
+    A mixed Poisson distribution has probablity mass function (pmf)
+    f(x) = sum_{j=1}^J w_j pi(x | lambda_j), x = 0, 1, 2, ...
+    where any
+    pi(x | lambda) = lambda^x * exp(-lambda) / x!
+    is the pmf of Poisson distribution.  Each lambda_j is called a component.
+    w_j is called the weight of component lambda_j.
+
+    At this moment, the fitting algorithm consists of a grid search of components
+    and a convex optimization on the weights of different components.
+    """
+
+    def __init__(
+        self,
+        frequency_histogram: np.ndarray,
+        ncomponents: int = 200,
+    ):
+        """Construct an optimizer for univariate mixed Poisson distribution.
+
+        Args:
+            frequency_histogram:  An array v where v[f] = number of observations
+                with frequency f, for 0 <= f <= F - 1, and v[F] = number of
+                observations with frequency >= F, for a max frequency F.
+                Note that the histogram starts from frequency 0.
+            ncomponents: Number of components in the Poisson mixture.  Based on
+                our experience, 100 components are enough, and more components
+                are also fine (they will not introduce overfitting).
+        """
+        self.validate_frequency_histogram(frequency_histogram)
+        self.observed_pmf = frequency_histogram / sum(frequency_histogram)
+        # Work with standardized histogram, i.e., pmf to avoid potential overflow.
+        self.max_freq = len(frequency_histogram) - 1
+        self.components = self.weighted_grid_sampling(ncomponents, self.observed_pmf)
+        self.fitted = False
+
+    @classmethod
+    def validate_frequency_histogram(cls, frequency_histogram: np.ndarray):
+        """Check if a frequency histogram is valid.
+
+        A valid frequency histogram has all elements being non-negative, and
+        sums up to be positive.
+        """
+        if len(frequency_histogram) < 2:
+            raise ValueError(
+                "Please provide a histogram including at least frequencies 0 and 1."
+            )
+        if not all(frequency_histogram >= 0):
+            raise ValueError("Histogram must be non-negative.")
+        if sum(frequency_histogram) <= 0:
+            raise ValueError("Histogram cannot be zeros.")
+
+    @classmethod
+    def weighted_grid_sampling(cls, ncomponents: int, pmf: np.ndarray) -> np.ndarray:
+        """Sampling grid according to a pmf.
+
+        For each frequency level, sample n_f points equally spaced in
+        [f, f + 1], where n_f (before rounding) is proportional to pmf[f].
+
+        Args:
+            ncomponents: Number of components to sample.
+            pmf: A vector of probabilities that sum up to be 1.
+
+        Returns:
+            All components in the model.
+        """
+        n_left = ncomponents
+        components = np.array([])
+        for f in range(len(pmf)):
+            n = int(ncomponents * pmf[f])
+            components = np.concatenate(
+                (components, np.linspace(f, f + 1, n, endpoint=False))
+            )
+            n_left -= n
+        if n_left > 0:
+            # Due to rounding, there can remain a certain number of components.
+            # Sample these remaining components in the next interval,
+            # that is, [F + 1, F + 2], where F is the maximum frequency.
+            components = np.concatenate(
+                (
+                    components,
+                    np.linspace(len(pmf), len(pmf) + 1, n_left, endpoint=False),
+                )
+            )
+        return components
+
+    @classmethod
+    def truncated_poisson_pmf_vec(
+        cls, poisson_mean: float, max_freq: int
+    ) -> np.ndarray:
+        """pmf vector of a Poisson distribution truncated at a max frequency.
+
+        Args:
+            poisson_mean: mean of Poisson distribution.
+            max_freq: Any observation beyond this maximum frequency will be
+                rounded to this maximum frequency.
+
+        Returns:
+            A vector v where v[f] = Poisson_pmf at f for f < max_freq, and
+            v[max_freq] = (probability >= max_freq)
+            = 1 - Poisson_cdf(max_freq - 1).
+        """
+        v = stats.poisson.pmf(range(max_freq + 1), poisson_mean)
+        v[-1] = 1 - stats.poisson.cdf(max_freq - 1, poisson_mean)
+        return v
+
+    @classmethod
+    def cross_entropy(cls, observed_arr: np.ndarray, fitted_arr: np.ndarray) -> float:
+        """The cross entropy distance between observed and fitted arrays.
+
+        Minimizing cross entropy is equivalent to maximizing likelihood.
+
+        Args:
+            observed_arr: A 1d array of the observed pmf. Or 2d array of the
+                observed pmfs on different directions.
+            fitted_arr: Any other array of pmf(s) that has the same dimension
+                as observed_arr.
+        Returns:
+             The cross entropy of the fitted pmf(s) relative to the observed
+             pmf(s), that is,
+            - sum_i observed_arr[i] * log(fitted_arr[i]) for 1d arrays,
+            - sum_{i, j} observed_arr[i, j] * log(fitted_arr[i, j]) for 2d arrays.
+        """
+        fitted_arr = fitted_arr + 1e-200
+        # Small shift to avoid log-zero numerical error.
+        return -cp.sum(cp.multiply(observed_arr, cp.log(fitted_arr)))
+
+    @classmethod
+    def solve_optimal_weights(
+        cls, observed_arr: np.ndarray, component_arrs: List, distance: Callable
+    ) -> np.ndarray:
+        """Convex optimization of weights on different components.
+
+        Args:
+            observed_arr: Any 1d or 2d arry.
+            component_arrs: A list of arrays that are of the same dimension
+                of observed_arr.
+            distance: A function on two arrays of the same dimension. Calculates
+                a certain distance between the two arrays.
+
+        Returns:
+            A weight vector such that the weighted sum of the arrays in
+            component_arrs is closest to observed_arr with respect to the given
+            distance.
+        """
+        ws = cp.Variable(len(component_arrs))
+        pred = cp.sum([cp.multiply(w, arr) for w, arr in zip(ws, component_arrs)])
+        problem = cp.Problem(
+            objective=cp.Minimize(distance(observed_arr, pred)),
+            constraints=[ws >= 0, cp.sum(ws) == 1],
+        )
+        problem.solve()
+        return ws.value
+
+    def fit(self):
+        """Fits a univariate mixed Poisson distribution."""
+        if self.fitted:
+            return
+        self.component_pmfs = [
+            self.truncated_poisson_pmf_vec(component, self.max_freq)
+            for component in self.components
+        ]
+        self.ws = self.solve_optimal_weights(
+            self.observed_pmf,
+            self.component_pmfs,
+            self.cross_entropy,
+        )
+        self.fitted = True
+
+    def predict(
+        self, scaling_factor: float, customized_max_freq: int = None
+    ) -> np.ndarray:
+        """Predict the frequency histogram when scaling the number of impressions.
+
+        The Dirac mixture model assumes that when scaling the number of
+        impressions, different Poisson components are scaled accordingly,
+        and that the pmf is shifted to the weighted sum of these scaled
+        Poisson distributions with the same weights.
+
+        Explicitly, if for the actual campaign its frequency distribution
+        is fitted as
+        sum_j w_j Poisson(lambda_j),
+        Then for a hypothetical campaign that has alpha times the number
+        of impressions of the actual campaign, its frequency distribution
+        is predicted as
+        sum_j w_j Poisson(alpha * lambda_j).
+
+        Args:
+            scaling_factor:  We predict the frequency histogram when the number
+                of impressions is scaling_factor times that of the observed
+                histogram.
+            customized_max_freq:  If specified, the predicted frequency
+                histogram will be capped by this maximum frequency.
+
+        Returns:
+            A vector v where v[f] is the pmf at f of the frequency.
+        """
+        if not self.fitted:
+            self.fit()
+        scaled_component_pmfs = [
+            self.truncated_poisson_pmf_vec(
+                poisson_mean=c * scaling_factor,
+                max_freq=(
+                    self.max_freq
+                    if customized_max_freq is None
+                    else customized_max_freq
+                ),
+            )
+            for c in self.components
+        ]
+        return sum([w * pmf for w, pmf in zip(self.ws, scaled_component_pmfs)])

--- a/src/models/dirac_mixture_single_publisher_model.py
+++ b/src/models/dirac_mixture_single_publisher_model.py
@@ -57,7 +57,9 @@ class UnivariateMixedPoissonOptimizer:
         self.observed_pmf = frequency_histogram / sum(frequency_histogram)
         # Work with standardized histogram, i.e., pmf to avoid potential overflow.
         self.max_freq = len(frequency_histogram) - 1
-        self.components = self.weighted_grid_sampling(ncomponents, self.observed_pmf)
+        self.components = self.in_bound_purely_weighted_grid(
+            ncomponents, self.observed_pmf
+        )
         self.fitted = False
 
     @staticmethod
@@ -77,38 +79,87 @@ class UnivariateMixedPoissonOptimizer:
             raise ValueError("Histogram cannot be zeros.")
 
     @staticmethod
-    def weighted_grid_sampling(ncomponents: int, pmf: np.ndarray) -> np.ndarray:
-        """Sampling grid according to a pmf.
+    def in_bound_grid(
+        ncomponents: int, pmf: np.ndarray, dilusion: float = 0
+    ) -> np.ndarray:
+        """Samples components from [0, max_freq] weighted by the observed pmf to an extent.
 
-        For each frequency level, sample n_f points equally spaced in
-        [f, f + 1], where n_f (before rounding) is proportional to pmf[f].
+        Main idea: A Poisson distribution has high pmf around its mean parameter.
+        So, if we observe a high pmf at a frequency level, we tend to draw more
+        Poisson components around it.
+
+        For example, if we observe a pmf of [0.5, 0.3, 0, 0.2] and want to draw
+        10 components, we may draw 5 components in [0, 1), 3 components in [1, 2),
+        0 components in [2, 3), and 2 components in [3, 4).  The components are
+        equally spaced within each interval of length 1.  We call it "purely
+        weighted" method of choosing components.  See the
+        `in_bound_purely_weighted_grid` method below.
+
+        The purely weighted method efficiently captures the areas that are most
+        likely to have components, but ignores the areas where the components
+        are unfortunately unobserved due to randomness/noise.  In the above toy
+        example, we do not sampling components between [2, 3), while there may
+        actually be one.  As such, our sampling weights can be chosen between
+        the observed pmf and the uniform pmf, in other words, we "dilute" the
+        sampling weights to cover unobserved areas.  See the explanation of the
+        `dilusion` argument below.
+
+        Note that this method is "in-bound": we do not draw any components beyond
+        max_freq.  So, it does not have a great fit in outlier cases where the
+        true average frequency is close to or even higher than the observable
+        max_freq.  We are thinking about methods to cover the beyond-bound
+        components and will submit another PR.
 
         Args:
             ncomponents: Number of components to sample.
             pmf: A vector of probabilities that sum up to be 1.
+            dilusion:  The sampling weights are chosen as (1 - dilusion) *
+                observed_pmf + dilusion * uniform_pmf.  No significant impact of
+                this parameter has been seen in initial simulations, but it is
+                worth further investigation.
 
         Returns:
             All components in the model.
         """
+        if dilusion > 0:
+            water = np.array([dilusion / len(pmf)] * len(pmf))
+            pmf = pmf * (1 - dilusion) + water
         n_left = ncomponents
         components = np.array([])
-        for f in range(len(pmf)):
-            n = int(ncomponents * pmf[f])
+        f = 0
+        while n_left > 0 and f < len(pmf):
+            n = int(round(ncomponents * pmf[f]))
             components = np.concatenate(
                 (components, np.linspace(f, f + 1, n, endpoint=False))
             )
             n_left -= n
+            f += 1
         if n_left > 0:
-            # Due to rounding, there can remain a certain number of components.
-            # Sample these remaining components in the next interval,
-            # that is, [F + 1, F + 2], where F is the maximum frequency.
             components = np.concatenate(
                 (
                     components,
-                    np.linspace(len(pmf), len(pmf) + 1, n_left, endpoint=False),
+                    np.linspace(f, f + 1, n_left, endpoint=False),
                 )
             )
         return components
+
+    @classmethod
+    def in_bound_purely_weighted_grid(
+        cls, ncomponents: int, pmf: np.ndarray
+    ) -> np.ndarray:
+        """Samples components from [0, max_freq] purely weighted by the observed pmf.
+
+        See the docstrings of the `in_bound_grid` method for more details.
+        """
+        return cls.in_bound_grid(ncomponents, pmf, dilusion=0)
+
+    @classmethod
+    def in_bound_uniform_grid(cls, ncomponents: int, pmf: np.ndarray) -> np.ndarray:
+        """Samples components uniformly from [0, max_freq].
+
+        See the docstrings of the `in_bound_grid` method for more details.
+        """
+        return cls.in_bound_grid(ncomponents, pmf, dilusion=1)
 
     @staticmethod
     def truncated_poisson_pmf_vec(poisson_mean: float, max_freq: int) -> np.ndarray:
@@ -125,14 +176,14 @@ class UnivariateMixedPoissonOptimizer:
             = 1 - Poisson_cdf(max_freq - 1).
         """
         v = stats.poisson.pmf(range(max_freq + 1), poisson_mean)
-        v[-1] = 1 - stats.poisson.cdf(max_freq - 1, poisson_mean)
+        v[-1] = stats.poisson.sf(max_freq - 1, poisson_mean)
         return v
 
     @staticmethod
     def cross_entropy(observed_arr: np.ndarray, fitted_arr: np.ndarray) -> float:
-        """The cross entropy distance between observed and fitted arrays.
+        """The cross entropy distance of fitted_arr relative to observed_arr.
 
-        Minimizing cross entropy is equivalent to maximizing likelihood.
+        Minimizing cross entropy is equivalent to maximizing the likelihood.
 
         Args:
             observed_arr: A 1d array of the observed pmf. Or 2d array of the
@@ -144,10 +195,31 @@ class UnivariateMixedPoissonOptimizer:
              pmf(s), that is,
             - sum_i observed_arr[i] * log(fitted_arr[i]) for 1d arrays,
             - sum_{i, j} observed_arr[i, j] * log(fitted_arr[i, j]) for 2d arrays.
+            If the input fitted_arr is a cvxpy expression, then the return is
+            also a cvxpy expression -- use .value to extract its value.
         """
         # Small shift to avoid log-zero numerical error.
         fitted_arr = fitted_arr + 1e-200
         return -cp.sum(cp.multiply(observed_arr, cp.log(fitted_arr)))
+
+    @staticmethod
+    def relative_entropy(observed_arr: np.ndarray, fitted_arr: np.ndarray) -> float:
+        """The relative entropy distance from fitted_arr relative to observed_arr.
+
+        Args:
+            observed_arr: A 1d array of the observed pmf. Or 2d array of the
+                observed pmfs on different directions.
+            fitted_arr: Any other array of pmf(s) that has the same dimension
+                as observed_arr.
+        Returns:
+            - sum_i observed_arr[i] * log(fitted_arr[i] / observed_arr[i])
+                for 1d arrays,
+            - sum_{i, j} observed_arr[i, j] * log(fitted_arr[i, j] / observed_arr[i, j])
+                for 2d arrays.
+            If the input fitted_arr is a cvxpy expression, then the return is
+            also a cvxpy expression -- use .value to extract its value.
+        """
+        return cp.sum(cp.rel_entr(observed_arr, fitted_arr))
 
     @staticmethod
     def solve_optimal_weights(

--- a/src/models/tests/dirac_mixture_single_publisher_model_test.py
+++ b/src/models/tests/dirac_mixture_single_publisher_model_test.py
@@ -1,0 +1,158 @@
+# Copyright 2021 The Private Cardinality Estimation Framework Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for dirac_mixture_single_publisher_model.py."""
+
+from absl.testing import absltest
+import numpy as np
+from wfa_planning_evaluation_framework.models.dirac_mixture_single_publisher_model import (
+    UnivariateMixedPoissonOptimizer,
+)
+
+
+class UnivariateMixedPoissonOptimizerTest(absltest.TestCase):
+    cls = UnivariateMixedPoissonOptimizer
+
+    def test_validate_frequency_histogram(self):
+        try:
+            self.cls.validate_frequency_histogram(np.array([0, 1, 1]))
+        except:
+            self.fail("Reject a valid histogram")
+        with self.assertRaises(ValueError):
+            self.cls.validate_frequency_histogram(np.array([0, 1, -1]))
+        with self.assertRaises(ValueError):
+            self.cls.validate_frequency_histogram(np.array([0, 0, 0]))
+
+    def test_weighted_grid_sampling(self):
+        pmf = np.array([0.2, 0.3, 0.5])
+        ncomponents = 8
+        res = self.cls.weighted_grid_sampling(ncomponents, pmf)
+        expected = np.array([0, 1, 1.5, 2, 2.25, 2.5, 2.75, 3])
+        self.assertSequenceAlmostEqual(res, expected, places=2)
+
+    def test_truncated_poisson_pmf_vec(self):
+        res = self.cls.truncated_poisson_pmf_vec(poisson_mean=1, max_freq=3)
+        expected = np.array([0.368, 0.368, 0.184, 0.0800])
+        self.assertSequenceAlmostEqual(res, expected, places=2)
+
+    def test_cross_entropy(self):
+        observed = np.array([[2, 3], [1, 4]])
+        fitted = np.array([[1, 3], [2, 4]])
+        res = self.cls.cross_entropy(observed, fitted).value
+        expected = -(2 * np.log(1) + 3 * np.log(3) + 1 * np.log(2) + 4 * np.log(4))
+        self.assertAlmostEqual(res, expected, places=2, msg="Unexpected for 2d array")
+        # Further test the case with zero
+        observed = np.array([[2, 3, 1, 0]])
+        fitted = np.array([[1, 3, 2, 0]])
+        res = self.cls.cross_entropy(observed, fitted).value
+        expected = -(2 * np.log(1) + 3 * np.log(3) + 1 * np.log(2) + 0)
+        self.assertAlmostEqual(res, expected, places=2, msg="Unexpected for 1d array")
+
+    def test_solve_optimal_weights(self):
+        observed = np.array([[1.5, 1.5], [1.5, 1.5]])
+        component_a = np.array([[1, 2], [2, 1]])
+        component_b = np.array([[2, 1], [1, 2]])
+        res = self.cls.solve_optimal_weights(
+            observed, [component_a, component_b], self.cls.cross_entropy
+        )
+        expected = np.array([0.5, 0.5])
+        self.assertSequenceAlmostEqual(res, expected, places=2)
+
+    def test_fit(self):
+        # zero reach
+        optimizer = self.cls(frequency_histogram=np.array([5, 0, 0, 0]), ncomponents=3)
+        optimizer.fit()
+        expected_ws = np.array([1, 0, 0])
+        expected_components = np.array([0, 0.333, 0.667])
+        self.assertSequenceAlmostEqual(
+            optimizer.ws,
+            expected_ws,
+            places=2,
+            msg="Unexpected weights for zero reach",
+        )
+        self.assertSequenceAlmostEqual(
+            optimizer.components,
+            expected_components,
+            places=2,
+            msg="Unexpected_components for zero reach",
+        )
+
+        # non-zero reach
+        optimizer = self.cls(frequency_histogram=np.array([3, 2, 2, 1]), ncomponents=4)
+        optimizer.fit()
+        expected_ws = np.array([0.133, 0.535, 0.332, 0])
+        expected_components = np.array([0, 1, 2, 4])
+        self.assertSequenceAlmostEqual(
+            optimizer.ws,
+            expected_ws,
+            places=2,
+            msg="Unexpected weights for non-zero reach",
+        )
+        self.assertSequenceAlmostEqual(
+            optimizer.components,
+            expected_components,
+            places=2,
+            msg="Unexpected_components for non-zero reach",
+        )
+
+    def test_predict(self):
+        optimizer = self.cls(frequency_histogram=np.array([3, 2, 1]), ncomponents=2)
+        # Set arbitray parameters for testing
+        optimizer.fitted = True
+        optimizer.components = np.array([0, 1])
+        optimizer.ws = np.array([0.3, 0.7])
+
+        # Zero scaling_factor
+        res = optimizer.predict(scaling_factor=0)
+        expected = np.array([1, 0, 0])
+        self.assertSequenceAlmostEqual(
+            res,
+            expected,
+            places=2,
+            msg="Unexpected for zero scaling, no customized_max_freq",
+        )
+        ## Test customized_max_freq
+        res = optimizer.predict(scaling_factor=0, customized_max_freq=1)
+        expected = np.array([1, 0])
+        self.assertSequenceAlmostEqual(
+            res,
+            expected,
+            places=2,
+            msg="Unexpected for zero scaling, smaller customized_max_freq",
+        )
+        res = optimizer.predict(scaling_factor=0, customized_max_freq=6)
+        expected = np.array([1, 0, 0, 0, 0, 0, 0])
+        self.assertSequenceAlmostEqual(
+            res,
+            expected,
+            places=2,
+            msg="Unexpected for zero scaling, larger customized_max_freq",
+        )
+
+        # Moderate scaling factor
+        res = optimizer.predict(scaling_factor=0.5)
+        expected = np.array([0.725, 0.212, 0.063])
+        self.assertSequenceAlmostEqual(
+            res, expected, places=2, msg="Unexpected for moderate scaling"
+        )
+
+        # Infinite scaling_factor
+        res = optimizer.predict(scaling_factor=10000)
+        expected = np.array([0.3, 0, 0.7])
+        self.assertSequenceAlmostEqual(
+            res, expected, places=2, msg="Unexpected for infinite scaling"
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
PR 102 contained 4 classes:
- UnivariateMixedPoissonOptimizer
- DiracMixtureSinglePublisherModel
- MultivariateMixedPoissonOptimizer
- DiracMixtureMultiPublisherModel

Following Matt's suggestion, I'm now splitting PR 102 into 4 PRs, each PR including one class.  This PR (103) is for the UnivariateMixedPoissonOptimizer class.

See this deck for some explanations on the functionality and algorithm:
https://docs.google.com/presentation/d/1YKLfLdHrokSQUApQNTPP0yBkWdN9wVSDYlUAWf9dzXU/edit#slide=id.p