### PR TITLE
Add the DiracMixtureSinglePublisherModel class

### DIFF
--- a/src/data_generators/data_set.py
+++ b/src/data_generators/data_set.py
@@ -51,7 +51,12 @@ class DataSet:
     have an IndependentDataSet, a SequentiallyCorrelatedDataSet, etc.
     """
 
-    def __init__(self, publisher_data_list: Iterable[PublisherData], name: str = None):
+    def __init__(
+        self,
+        publisher_data_list: Iterable[PublisherData],
+        name: str = None,
+        universe_size: int = None,
+    ):
         """Constructor
 
         Args:
@@ -62,6 +67,8 @@ class DataSet:
             of the parameters that were used to create this DataSet,
             such as "homog_p=10_rep=3".  If no name is given, then a random
             digit string is assigned as the name.
+          universe_size:  The universe size associated with this DataSet.
+            Every reached user in this DataSet belongs to this universe.
         """
         self._data = deepcopy(publisher_data_list)
 
@@ -74,6 +81,14 @@ class DataSet:
             self._name = name
         else:
             self._name = "{:012d}".format(randint(0, 1e12))
+        if universe_size is None:
+            # As a temporarily solution, set a default universe size
+            # as twice the maximum reach.
+            # TODO(jiayu) Discuss whether there is a need to
+            # tweak this default universe size in the evaluation.
+            self._universe_size = 2 * self.maximum_reach
+        else:
+            self._universe_size = universe_size
 
     @property
     def publisher_count(self):
@@ -84,6 +99,11 @@ class DataSet:
     def maximum_reach(self):
         """Total number of reachable people across all publishers."""
         return self._maximum_reach
+
+    @property
+    def universe_size(self):
+        """he universe size associated with this DataSet."""
+        return self._universe_size
 
     @property
     def name(self):

--- a/src/data_generators/data_set.py
+++ b/src/data_generators/data_set.py
@@ -172,7 +172,7 @@ class DataSet:
             for id, freq in self._data[i].user_counts_by_impressions(imp).items():
                 counts[id] += freq
         kplus_reaches = self._counts_to_histogram(counts, max_frequency)
-        return ReachPoint(impressions, kplus_reaches, spends)
+        return ReachPoint(impressions, kplus_reaches, spends, self.universe_size)
 
     def _counts_to_histogram(
         self, counts: Dict[int, int], max_frequency: int
@@ -218,7 +218,7 @@ class DataSet:
             for id, freq in user_counts.items():
                 counts[id] += freq
         kplus_reaches = self._counts_to_histogram(counts, max_frequency)
-        return ReachPoint(impressions, kplus_reaches, spends)
+        return ReachPoint(impressions, kplus_reaches, spends, self.universe_size)
 
     def write_data_set(
         self,

--- a/src/data_generators/data_set.py
+++ b/src/data_generators/data_set.py
@@ -82,7 +82,7 @@ class DataSet:
         else:
             self._name = "{:012d}".format(randint(0, 1e12))
         if universe_size is None:
-            # As a temporarily solution, set a default universe size
+            # As a temporary solution, set the default universe size
             # as twice the maximum reach.
             # TODO(jiayu) Discuss whether there is a need to
             # tweak this default universe size in the evaluation.

--- a/src/data_generators/tests/data_set_test.py
+++ b/src/data_generators/tests/data_set_test.py
@@ -61,6 +61,7 @@ class DataSetTest(absltest.TestCase):
         self.assertEqual(self.data_set.reach_by_impressions([0, 2]).reach(), 2)
         self.assertEqual(self.data_set.reach_by_impressions([4, 2]).reach(), 4)
         self.assertEqual(self.data_set.reach_by_impressions([3, 1]).reach(), 2)
+        self.assertEqual(self.data_set.reach_by_impressions([0, 0]).universe_size, 8)
 
     def test_reach_by_spend(self):
         self.assertEqual(self.data_set.reach_by_spend([0, 0]).reach(), 0)

--- a/src/data_generators/tests/data_set_test.py
+++ b/src/data_generators/tests/data_set_test.py
@@ -39,6 +39,8 @@ class DataSetTest(absltest.TestCase):
     def test_properties(self):
         self.assertEqual(self.data_set.publisher_count, 2)
         self.assertEqual(self.data_set.name, "test")
+        self.assertEqual(self.data_set.maximum_reach, 4)
+        self.assertEqual(self.data_set.universe_size, 8)
 
     def test_spend_by_impressions(self):
         self.assertEqual(self.data_set.spend_by_impressions([0, 0]), [0, 0])

--- a/src/models/dirac_mixture_single_publisher_model.py
+++ b/src/models/dirac_mixture_single_publisher_model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Dirac mixture single publisher model."""
 
+from absl import logging
 import numpy as np
 import cvxpy as cp
 from scipy import stats
@@ -414,12 +415,13 @@ class DiracMixtureSinglePublisherModel(ReachCurve):
             try:
                 self.optimizer.fit()
                 break
-            except:
+            except Exception as inst:
                 # There is a tiny chance of exception when cvxpy mistakenly
                 # thinks the problem is non-convex due to numerical errors.
                 # If this occurs, it is likely that we have a large number
                 # of components.  In this case, try reducing the number of
                 # components.
+                logging.vlog(1, f"Optimizer failure: {inst}")
                 self.ncomponents = int(self.ncomponents / 2)
                 continue
         self._fit_computed = True

--- a/src/models/dirac_mixture_single_publisher_model.py
+++ b/src/models/dirac_mixture_single_publisher_model.py
@@ -343,7 +343,7 @@ class DiracMixtureSinglePublisherModel(ReachCurve):
             )
         self._data = data
         self._reach_point = data[0]
-        self.hist = self._reach_point.zero_included_histogram
+        self.hist = np.array(self._reach_point.zero_included_histogram)
         if data[0].spends:
             self._cpi = data[0].spends[0] / data[0].impressions[0]
         else:

--- a/src/models/dirac_mixture_single_publisher_model.py
+++ b/src/models/dirac_mixture_single_publisher_model.py
@@ -384,13 +384,13 @@ class DiracMixtureSinglePublisherModel(ReachCurve):
         """Returns the estimated reach as a function of impressions.
 
         Args:
-          impressions: list of ints of length 1, specifying the hypothetical number
-            of impressions that are shown.
-          max_frequency: int, specifies the number of frequencies for which reach
-            will be reported.
+            impressions: list of ints of length 1, specifying the hypothetical number
+                of impressions that are shown.
+            max_frequency: int, specifies the number of frequencies for which reach
+                will be reported.
 
         Returns:
-          A ReachPoint specifying the estimated reach for this number of e.
+            A ReachPoint specifying the estimated reach for this number of e.
         """
         if len(impressions) != 1:
             raise ValueError("Impressions vector must have a length of 1.")
@@ -417,11 +417,12 @@ class DiracMixtureSinglePublisherModel(ReachCurve):
         """Returns the estimated reach as a function of spend assuming constant CPM.
 
         Args:
-          spend: list of floats of length 1, specifying the hypothetical spend.
-          max_frequency: int, specifies the number of frequencies for which reach
-            will be reported.
+            spend: list of floats of length 1, specifying the hypothetical spend.
+            max_frequency: int, specifies the number of frequencies for which reach
+                will be reported.
+                
         Returns:
-          A ReachPoint specifying the estimated reach for this number of impressions.
+            A ReachPoint specifying the estimated reach for this number of impressions.
         """
         if len(spends) != 1:
             raise ValueError("Spend vector must have a length of 1.")

--- a/src/models/dirac_mixture_single_publisher_model.py
+++ b/src/models/dirac_mixture_single_publisher_model.py
@@ -356,42 +356,6 @@ class DiracMixtureSinglePublisherModel(ReachCurve):
         self.ncomponents = ncomponents
         self._fit_computed = False
 
-    @staticmethod
-    def debiased_clip(noised_histogram: np.ndarray) -> np.ndarray:
-        """Clip a histogram to be non-negative without introducing much bias.
-
-        The observed, noised histogram may have negative counts.  We can
-        round these negative values to zero, but it introduces positive
-        biases.  In particular, the 1+ reach is inflated.
-
-        This method mitigates such positive biases.  The algorithm is as
-        follows.  Iterating from the maximum frequency to one,
-        (1) whenever we round a negative count to zero, we record the bias
-        that is introduced
-        (2) when seeing a positive count in the next frequency levels, we try
-        to substract this positive count by the bias.
-        In this way, we can (almost) guarantee that no bias is introduced at
-        least in the 1+ reach.
-
-        Args:
-            noised_histogram:  A noised frequency histogram of which some
-                elements can be negative.
-
-        Returns:
-            A non-negative histogram of which the cumsums are as close to
-            those of the given histogram as possiblle.
-        """
-        cumulative_bias = 0
-        for i in range(len(noised_histogram) - 1, -1, -1):
-            if noised_histogram[i] < 0:
-                cumulative_bias += 0 - noised_histogram[i]
-                noised_histogram[i] = 0
-            elif cumulative_bias > 0:
-                pay_back = min(cumulative_bias, noised_histogram[i])
-                noised_histogram[i] -= pay_back
-                cumulative_bias -= pay_back
-        return noised_histogram
-
     def _fit(self):
         """Fit the model."""
         if self._fit_computed:

--- a/src/models/dirac_mixture_single_publisher_model.py
+++ b/src/models/dirac_mixture_single_publisher_model.py
@@ -343,15 +343,16 @@ class DiracMixtureSinglePublisherModel(ReachCurve):
             )
         self._data = data
         self._reach_point = data[0]
+        self.hist = self._reach_point.zero_included_histogram
         if data[0].spends:
             self._cpi = data[0].spends[0] / data[0].impressions[0]
         else:
             self._cpi = None
         if self._reach_point.universe_size is None:
             raise ValueError(
-                "Dirac mixture model only works when the universe size is given"
+                "A fit requires the universe size to be known, "
+                "please provide a ReachPoint with a known universe size instead."
             )
-        self.hist = self.obtain_zero_included_histogram()
         self.ncomponents = ncomponents
         self._fit_computed = False
 
@@ -390,19 +391,6 @@ class DiracMixtureSinglePublisherModel(ReachCurve):
                 noised_histogram[i] -= pay_back
                 cumulative_bias -= pay_back
         return noised_histogram
-
-    def obtain_zero_included_histogram(self):
-        """Obtain a zero-included frequency histogram from a ReachPoint.
-
-        Translate self._reach_point to a vector v where v[f] is the reach at
-        frequency f, for 0 <= f <= F - 1, and v[F] = the reach with frequency
-        >= F, where F is the maximum frequency of the given ReachPoint.
-        """
-        return np.array(
-            [self._reach_point.universe_size - self._reach_point.reach(1)]
-            + self._reach_point._frequencies
-            + [self._reach_point._kplus_reaches[-1]]
-        )
 
     def _fit(self):
         """Fit the model."""

--- a/src/models/reach_point.py
+++ b/src/models/reach_point.py
@@ -29,6 +29,7 @@ class ReachPoint:
         impressions: Iterable[int],
         kplus_reaches: Iterable[int],
         spends: Iterable[float] = None,
+        universe_size: int = None,
     ):
         """Represents a single point on a reach surface.
 
@@ -40,22 +41,34 @@ class ReachPoint:
             is the number of people who were reached AT LEAST k+1 times.
           spends:  If given, the amount that was spent at this point on each
             publisher.  An iterable.
+          universe_size:  If given, the universe size associated with this
+            reach point.
         """
         if spends and len(impressions) != len(spends):
             raise ValueError("impressions and spends must have same length")
         self._impressions = tuple(impressions)
         self._kplus_reaches = tuple(kplus_reaches)
-        self._frequencies = [kplus_reaches[i] - kplus_reaches[i+1]
-                             for i in range(len(kplus_reaches)-1)]
+        self._frequencies = [
+            kplus_reaches[i] - kplus_reaches[i + 1]
+            for i in range(len(kplus_reaches) - 1)
+        ]
         if spends:
             self._spends = tuple(spends)
         else:
             self._spends = None
+        self._universe_size = universe_size
 
     @property
     def impressions(self) -> int:
         """Returns the number of impressions associated with this point."""
         return self._impressions
+
+    @property
+    def universe_size(self) -> int:
+        """Returns the universe size associated with this point."""
+        if self._universe_size is None:
+            raise ValueError("Universe size is not given in this ReachPoint")
+        return self._universe_size
 
     @property
     def max_frequency(self) -> int:
@@ -80,7 +93,7 @@ class ReachPoint:
                     k, len(self._kplus_reaches)
                 )
             )
-        return self._frequencies[k-1]
+        return self._frequencies[k - 1]
 
     @property
     def frequencies(self) -> List[int]:

--- a/src/models/reach_point.py
+++ b/src/models/reach_point.py
@@ -19,6 +19,7 @@ Represents a single point on either a reach curve or a reach surface.
 from typing import Dict
 from typing import Iterable
 from typing import List
+import numpy as np
 
 
 class ReachPoint:
@@ -102,6 +103,23 @@ class ReachPoint:
     @property
     def frequencies_with_kplus_bucket(self) -> List[int]:
         return self._frequencies + [self._kplus_reaches[-1]]
+
+    @property
+    def zero_included_histogram(self) -> np.ndarray:
+        """The zero-included frequency histogram of a ReachPoint.
+
+        Translate the ReachPoint to a vector v where v[f] is the reach at
+        frequency f, for 0 <= f <= F - 1, and v[F] = the reach with frequency
+        >= F, where F is the maximum frequency of the given ReachPoint.
+        """
+        if self._universe_size is None:
+            raise ValueError(
+                "It requires the universe size to be known to obtain a zero-included histogram. "
+                "Please specify the universe size of this ReachPoint."
+            )
+        return np.array(
+            [self.universe_size - self.reach(1)] + self.frequencies_with_kplus_bucket
+        )
 
     @property
     def spends(self) -> Iterable[float]:

--- a/src/models/reach_point.py
+++ b/src/models/reach_point.py
@@ -105,7 +105,7 @@ class ReachPoint:
         return self._frequencies + [self._kplus_reaches[-1]]
 
     @property
-    def zero_included_histogram(self) -> np.ndarray:
+    def zero_included_histogram(self) -> List[int]:
         """The zero-included frequency histogram of a ReachPoint.
 
         Translate the ReachPoint to a vector v where v[f] is the reach at

--- a/src/models/reach_point.py
+++ b/src/models/reach_point.py
@@ -117,9 +117,7 @@ class ReachPoint:
                 "It requires the universe size to be known to obtain a zero-included histogram. "
                 "Please specify the universe size of this ReachPoint."
             )
-        return np.array(
-            [self.universe_size - self.reach(1)] + self.frequencies_with_kplus_bucket
-        )
+        return [self.universe_size - self.reach(1)] + self.frequencies_with_kplus_bucket
 
     @property
     def spends(self) -> Iterable[float]:

--- a/src/models/tests/dirac_mixture_single_publisher_model_test.py
+++ b/src/models/tests/dirac_mixture_single_publisher_model_test.py
@@ -199,12 +199,6 @@ class DiracMixtureSinglePublisherModelTest(parameterized.TestCase):
         expected = np.array([20, 1, 0, 0])
         self.assertSequenceAlmostEqual(res, expected, places=2)
 
-    def test_obtain_zero_included_histogram(self):
-        rp = ReachPoint(impressions=[10], kplus_reaches=[5, 3, 2], universe_size=10)
-        res = self.cls([rp]).hist
-        expected = np.array([5, 2, 1, 2])
-        self.assertSequenceAlmostEqual(res, expected)
-
     def test_fit_with_zero_reach(self):
         rp = ReachPoint(impressions=[10], kplus_reaches=[0], universe_size=10)
         model = self.cls(data=[rp], ncomponents=2)

--- a/src/models/tests/dirac_mixture_single_publisher_model_test.py
+++ b/src/models/tests/dirac_mixture_single_publisher_model_test.py
@@ -14,9 +14,13 @@
 """Tests for dirac_mixture_single_publisher_model.py."""
 
 from absl.testing import absltest
+from absl.testing import parameterized
 import numpy as np
+from wfa_planning_evaluation_framework.models.reach_curve import ReachCurve
+from wfa_planning_evaluation_framework.models.reach_point import ReachPoint
 from wfa_planning_evaluation_framework.models.dirac_mixture_single_publisher_model import (
     UnivariateMixedPoissonOptimizer,
+    DiracMixtureSinglePublisherModel,
 )
 
 
@@ -153,6 +157,83 @@ class UnivariateMixedPoissonOptimizerTest(absltest.TestCase):
         res = optimizer.predict(scaling_factor=0.5)
         expected = np.array([0.725, 0.212, 0.063])
         self.assertSequenceAlmostEqual(res, expected, places=2)
+
+
+class DiracMixtureSinglePublisherModelTest(parameterized.TestCase):
+    cls = DiracMixtureSinglePublisherModel
+
+    def test_debiased_clip(self):
+        res = self.cls.debiased_clip(noised_histogram=np.array([20, 6, -3, -2]))
+        expected = np.array([20, 1, 0, 0])
+        self.assertSequenceAlmostEqual(res, expected, places=2)
+
+    def test_obtain_zero_included_histogram(self):
+        rp = ReachPoint(impressions=[10], kplus_reaches=[5, 3, 2])
+        res = self.cls.obtain_zero_included_histogram(universe_size=8, rp=rp)
+        expected = np.array([3, 2, 1, 2])
+        self.assertSequenceAlmostEqual(res, expected)
+
+    def test_fit_with_zero_reach(self):
+        rp = ReachPoint(impressions=[10], kplus_reaches=[0])
+        model = self.cls(data=[rp], ncomponents=2)
+        model._fit()
+        expected = np.array([1, 0])
+        self.assertSequenceAlmostEqual(model.optimizer.ws, expected, places=2)
+
+    def test_fit_with_non_zero_reach(self):
+        rp = ReachPoint(impressions=[10], kplus_reaches=[3], spends=[1.0])
+        model = self.cls(data=[rp], ncomponents=2)
+        model._fit()
+        expected = np.array([0.614, 0.386])
+        self.assertSequenceAlmostEqual(model.optimizer.ws, expected, places=2)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "zero_impression", "impressions": 0, "expected": 0},
+        {"testcase_name": "sample_impressions", "impressions": 10, "expected": 3},
+        {"testcase_name": "double_impressions", "impressions": 20, "expected": 4},
+    )
+    def test_by_impressions(self, impressions: int, expected: int):
+        rp = ReachPoint(impressions=[10], kplus_reaches=[3])
+        model = self.cls(data=[rp], ncomponents=5)
+        res = model.by_impressions(impressions=[impressions])
+        self.assertEqual(
+            res._kplus_reaches[0],
+            expected,
+        )
+
+    def test_by_impressions_with_infinite_impressions(self):
+        rp = ReachPoint(impressions=[10], kplus_reaches=[3])
+        model = self.cls(data=[rp], ncomponents=5)
+        res = model.by_impressions(impressions=[10000])
+        expected = round(model.N * (1 - model.optimizer.ws[0]), 0)
+        self.assertEqual(
+            res._kplus_reaches[0],
+            expected,
+        )
+
+    @parameterized.named_parameters(
+        {"testcase_name": "zero_spend", "spend": 0.0, "expected": 0},
+        {"testcase_name": "sample_spend", "spend": 1.0, "expected": 3},
+        {"testcase_name": "double_spend", "spend": 2.0, "expected": 4},
+    )
+    def test_by_spend(self, spend: float, expected: int):
+        rp = ReachPoint(impressions=[10], kplus_reaches=[3], spends=[1.0])
+        model = self.cls(data=[rp], ncomponents=5)
+        res = model.by_spend(spends=[spend])
+        self.assertEqual(
+            res._kplus_reaches[0],
+            expected,
+        )
+
+    def test_by_spend_with_infinite_spend(self):
+        rp = ReachPoint(impressions=[10], kplus_reaches=[3], spends=[1.0])
+        model = self.cls(data=[rp], ncomponents=5)
+        res = model.by_spend(spends=[10000.0])
+        expected = round(model.N * (1 - model.optimizer.ws[0]), 0)
+        self.assertEqual(
+            res._kplus_reaches[0],
+            expected,
+        )
 
 
 if __name__ == "__main__":

--- a/src/models/tests/dirac_mixture_single_publisher_model_test.py
+++ b/src/models/tests/dirac_mixture_single_publisher_model_test.py
@@ -194,11 +194,6 @@ class UnivariateMixedPoissonOptimizerTest(absltest.TestCase):
 class DiracMixtureSinglePublisherModelTest(parameterized.TestCase):
     cls = DiracMixtureSinglePublisherModel
 
-    def test_debiased_clip(self):
-        res = self.cls.debiased_clip(noised_histogram=np.array([20, 6, -3, -2]))
-        expected = np.array([20, 1, 0, 0])
-        self.assertSequenceAlmostEqual(res, expected, places=2)
-
     def test_fit_with_zero_reach(self):
         rp = ReachPoint(impressions=[10], kplus_reaches=[0], universe_size=10)
         model = self.cls(data=[rp], ncomponents=2)

--- a/src/models/tests/reach_point_test.py
+++ b/src/models/tests/reach_point_test.py
@@ -14,6 +14,7 @@
 """Tests for reach_point.py."""
 
 from absl.testing import absltest
+import numpy as np
 
 from wfa_planning_evaluation_framework.models.reach_point import ReachPoint
 
@@ -53,6 +54,11 @@ class ReachPointTest(absltest.TestCase):
         self.assertEqual(ReachPoint.frequencies_to_kplus_reaches([]), [])
         self.assertEqual(ReachPoint.frequencies_to_kplus_reaches([1]), [1])
         self.assertEqual(ReachPoint.frequencies_to_kplus_reaches([2, 1]), [3, 1])
+
+    def test_zero_included_histogram(self):
+        rp = ReachPoint(impressions=[10], kplus_reaches=[5, 3, 2], universe_size=10)
+        expected = np.array([5, 2, 1, 2])
+        np.testing.assert_equal(rp.zero_included_histogram, expected)
 
     def test_user_counts_to_frequencies(self):
         self.assertEqual(ReachPoint.user_counts_to_frequencies({}, 3), [0, 0, 0])

--- a/src/models/tests/reach_point_test.py
+++ b/src/models/tests/reach_point_test.py
@@ -24,6 +24,12 @@ class ReachPointTest(absltest.TestCase):
         self.assertEqual(point.impressions[0], 200)
         self.assertEqual(point.impressions[1], 300)
 
+    def test_universe_size(self):
+        point = ReachPoint(
+            impressions=[200, 300], kplus_reaches=[150, 100], universe_size=400
+        )
+        self.assertEqual(point.universe_size, 400)
+
     def test_reach(self):
         point = ReachPoint([200, 300], [100, 50])
         self.assertEqual(point.reach(1), 100)

--- a/src/models/tests/reach_point_test.py
+++ b/src/models/tests/reach_point_test.py
@@ -57,7 +57,7 @@ class ReachPointTest(absltest.TestCase):
 
     def test_zero_included_histogram(self):
         rp = ReachPoint(impressions=[10], kplus_reaches=[5, 3, 2], universe_size=10)
-        expected = np.array([5, 2, 1, 2])
+        expected = [5, 2, 1, 2]
         np.testing.assert_equal(rp.zero_included_histogram, expected)
 
     def test_user_counts_to_frequencies(self):


### PR DESCRIPTION
PR 102 contained 4 classes:

- UnivariateMixedPoissonOptimizer
- DiracMixtureSinglePublisherModel
- MultivariateMixedPoissonOptimizer
- DiracMixtureMultiPublisherModel

Following Matt's suggestion, I'm splitting PR 102 into 4 PRs, each PR including one class. This PR (105) is for `DiracMixtureSinglePublisherModel`, which subclass of ReachCurve that realizes the impression Dirac mixture single pub model.  See pages 8 - 9 of [this companion deck](https://docs.google.com/presentation/d/1YKLfLdHrokSQUApQNTPP0yBkWdN9wVSDYlUAWf9dzXU/edit#slide=id.g115747fa988_0_221).


The previous PR 103 is for the UnivariateMixedPoissonOptimizer class.